### PR TITLE
python3.7 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 platform: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ['3.8', '3.9']
+                python-version: ["3.7", "3.8", "3.9"]
                 # No gpu workflow yet!: https://github.com/apache/singa/issues/802
 
         steps:
@@ -25,10 +25,10 @@ jobs:
 
             - name: Install dependencies
               run: |
-                python -m pip install --upgrade pip
-                python -m pip install tox tox-gh-actions
+                  python -m pip install --upgrade pip
+                  python -m pip install tox tox-gh-actions
 
             - name: Test with tox
               run: tox
               env:
-                PLATFORM: ${{ matrix.platform }}
+                  PLATFORM: ${{ matrix.platform }}

--- a/cooper/__init__.py
+++ b/cooper/__init__.py
@@ -1,6 +1,11 @@
 """Top-level package for Constrained Optimization in Pytorch."""
 
-from importlib.metadata import PackageNotFoundError, version
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import PackageNotFoundError, version
+else:
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("cooper")

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     torch>=1.8.1
     numpy>=1.21.0
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.7
 
 [options.package_data]
 cooper = py.typed
@@ -78,7 +78,7 @@ tests =
     flake8==4.0.1
     isort==5.10.1
     mypy==0.931
-    numpy==1.22.0
+    numpy==1.21.0
     pre-commit==2.16.0
     pytest==6.2.5
     pytest-cov==3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 minversion = 3.8.0
-envlist =  py{38,39}-torch{18, 19, 110}-{linux,macos,windows}, lint, mypy
+envlist =  py{37,38,39}-torch{18, 19, 110}-{linux,macos,windows}, lint, mypy
 isolated_build = true
 
 [gh-actions]
 python =
+    3.7: py37
     3.8: py38, lint, mypy
     3.9: py39
 
@@ -18,6 +19,7 @@ PLATFORM =
 setenv =
     PYTHONPATH = {toxinidir}
 extras = tests
+whitelist_externals = pytest
 deps =
     torch18: torch >= 1.8.0, < 1.9.0
     torch19: torch >= 1.9.0, < 1.10.0


### PR DESCRIPTION
Closes #22 

## Changes

- "python_requires = >=3.7" in setup.cfg.
- add 3.7 to tox and build.yml (github actions) tests.
- importlib.metadata exists for python versions 3.8 and above. For 3.7, importlib_metadata is used. Added an if statement in cooper's __init__ so that imports work for 3.7 and 3.8+. 
- changed numpy's testing dependency to match the minimum dev dependency (1.21.0)

## Testing

Ran tox locally (including new envs on 3.7). 