### PR TITLE
Alternating updates

### DIFF
--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -9,6 +9,7 @@ methods:
 """
 
 import pdb
+import warnings
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Type
 
@@ -170,6 +171,12 @@ class ConstrainedOptimizer:
         # whether to use extrapolation. See check below for matching
         # extrapolation behavior.
         self.is_extrapolation = hasattr(self.primal_optimizer, "extrapolation")
+
+        if is_alternating and self.dual_restarts:
+            warnings.warn(
+                """Using alternating updates with dual restarts is untested.
+                Please use with caution."""
+            )
 
         if is_aug_lag and self.is_extrapolation:
             raise NotImplementedError(

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -241,6 +241,10 @@ class ConstrainedOptimizer:
                 function when re-evaluating.
         """
 
+        # TODO (JGP): The logic inside this method is becoming overly complex
+        # due to the constant friction between extrapolation, alternating
+        # updates, and proxy-constraints. We might want to consider refactoring.
+
         if self.cmp.is_constrained and not hasattr(self.dual_optimizer, "param_groups"):
             assert self.dual_optimizer is not None and callable(self.dual_optimizer)
             # Checks if needed and instantiates dual_optimizer
@@ -302,6 +306,11 @@ class ConstrainedOptimizer:
                     # Skip gradient wrt model parameters to avoid wasteful
                     # computation, as we only need gradient wrt multipliers.
                     with torch.no_grad():
+
+                        # TODO (JGP): This could be made more efficient by not
+                        # computing the whole closure but rather *just the
+                        # constraint violations*
+
                         assert closure is not None
                         self.cmp.state = closure(*closure_args, **closure_kwargs)
 

--- a/cooper/lagrangian_formulation.py
+++ b/cooper/lagrangian_formulation.py
@@ -1,6 +1,7 @@
 """Lagrangian formulation"""
 
 import abc
+import pdb
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, no_type_check
 
 import torch
@@ -233,6 +234,7 @@ class LagrangianFormulation(BaseLagrangianFormulation):
         self,
         closure: Callable[..., CMPState],
         *closure_args,
+        pre_computed_state: Optional[CMPState] = None,
         write_state: bool = True,
         **closure_kwargs
     ) -> torch.Tensor:
@@ -252,6 +254,8 @@ class LagrangianFormulation(BaseLagrangianFormulation):
 
         Args:
             closure: Callable returning a :py:class:`cooper.problem.CMPState`
+            pre_computed_state: Pre-computed CMP state to avoid wasteful
+                computation when only dual gradients are required.
             write_state: If ``True``, the ``state`` of the formulation's
                 :py:class:`cooper.problem.ConstrainedMinimizationProblem`
                 attribute is replaced by that returned by the ``closure``
@@ -262,7 +266,10 @@ class LagrangianFormulation(BaseLagrangianFormulation):
 
         """
 
-        cmp_state = closure(*closure_args, **closure_kwargs)
+        if pre_computed_state is not None:
+            cmp_state = pre_computed_state
+        else:
+            cmp_state = closure(*closure_args, **closure_kwargs)
         if write_state:
             self.cmp.state = cmp_state
 

--- a/docs/source/constrained_optimizer.rst
+++ b/docs/source/constrained_optimizer.rst
@@ -179,7 +179,7 @@ Formally,
 Other update strategies implemented by :py:class:`~ConstrainedOptimizer`
 include:
 
-- (TODO) :ref:`Alternating updates<alternating_updates>` for (projected) gradient descent-ascent
+- :ref:`Alternating updates<alternating_updates>` for (projected) gradient descent-ascent
 - Performing :ref:`dual_restarts` on the Lagrange multipliers for inequality constraints
 - Using :ref:`Extra-gradient<extra-gradient_optimizers>`
 
@@ -234,12 +234,12 @@ variables. This two-stage process is handled by **Cooper** inside the
     to the Lagrange multipliers, it suffices to *evaluate* the constraint
     defects (through a call to
     :py:meth:`~cooper.problem.ConstrainedMinimizationProblem.closure`). This
-    operation does not require a having to back-propagate through the Lagrangian.
+    operation does not require a having to back-propagate through the Lagrangian
+    with respect to the primal parameters.
 
-.. todo::
-
-    This functionality is untested and is yet to be integrated with the use of
-    proxy constraints.
+    The current implementation re-evaluates the closure inside a
+    :py:meth:`torch.nograd()` context. Future releases might allow for
+    evaluating the constraints only.
 
 .. _dual_restarts:
 

--- a/docs/source/constrained_optimizer.rst
+++ b/docs/source/constrained_optimizer.rst
@@ -241,6 +241,12 @@ variables. This two-stage process is handled by **Cooper** inside the
     :py:meth:`torch.nograd()` context. Future releases might allow for
     evaluating the constraints only.
 
+
+.. warning::
+
+    Combining alternating updates with :ref:`dual restarts<dual_restarts>` is untested. Use at your
+    own risk.
+
 .. _dual_restarts:
 
 Dual restarts

--- a/tests/test_alternating_proxy.py
+++ b/tests/test_alternating_proxy.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+"""Tests for Constrained Optimizer class."""
+
+import functools
+import pdb
+
+import pytest
+import testing_utils
+import torch
+
+# Import basic closure example from helpers
+import toy_2d_problem
+
+import cooper
+
+
+@pytest.mark.parametrize("aim_device", ["cpu", "cuda"])
+def test_toy_problem(aim_device):
+    """
+    Simple test on a bi-variate quadratic programming problem
+        min x**2 + 2*y**2
+        st.
+            x + y >= 1
+            x**2 + y <= 1.
+
+    Verified solution from WolframAlpha (x=2/3, y=1/3)
+    Link to WolframAlpha query: https://tinyurl.com/ye8dw6t3
+    """
+
+    device, skip = testing_utils.get_device_skip(aim_device, torch.cuda.is_available())
+
+    if skip.do_skip:
+        pytest.skip(skip.skip_reason)
+
+    params = torch.nn.Parameter(torch.tensor([0.0, -1.0], device=device))
+    primal_optimizer = torch.optim.SGD([params], lr=5e-2, momentum=0.0)
+    dual_optimizer = cooper.optim.partial_optimizer(torch.optim.SGD, lr=1e-2)
+
+    cmp = toy_2d_problem.Toy2dCMP(use_ineq=True, use_proxy_ineq=True)
+    formulation = cooper.LagrangianFormulation(cmp)
+
+    coop = cooper.ConstrainedOptimizer(
+        formulation=formulation,
+        primal_optimizer=primal_optimizer,
+        dual_optimizer=dual_optimizer,
+        dual_restarts=False,
+        alternating=True,
+    )
+
+    # Helper function to instantiate tensors in correct device
+    mktensor = functools.partial(torch.tensor, device=device)
+
+    # ----------------------- First iteration -----------------------
+    coop.zero_grad()
+    lagrangian = formulation.composite_objective(cmp.closure, params)
+
+    # Check loss, proxy and non-proxy defects after forward pass
+    assert torch.allclose(lagrangian, mktensor(2.0))
+    assert torch.allclose(cmp.state.loss, mktensor(2.0))
+    assert torch.allclose(cmp.state.ineq_defect, mktensor([2.0, -2.0]))
+    assert torch.allclose(cmp.state.proxy_ineq_defect, mktensor([2.0, -1.9]))
+    assert cmp.state.eq_defect is None
+    assert cmp.state.proxy_eq_defect is None
+
+    # Multiplier initialization
+    assert torch.allclose(formulation.state()[0], mktensor([0.0, 0.0]))
+    assert formulation.state()[1] is None
+
+    # Check primal and dual gradients after backward. Dual gradient must match
+    # ineq_defect
+    formulation.custom_backward(lagrangian)
+    assert torch.allclose(params.grad, mktensor([0.0, -4.0]))
+    assert torch.allclose(formulation.state()[0].grad, cmp.state.ineq_defect)
+
+    # Must pass closrue again to compute constraints for alternating update
+    coop.step(cmp.closure, params)
+
+    assert torch.allclose(params, mktensor([0.0, -0.8]))
+    # Loss and constraints are evaluated at updated primal variables
+    assert torch.allclose(cmp.state.loss, mktensor([2 * (-0.8) ** 2]))
+    # Constraint defects [1.8, -1.8] --> this is used to update multipliers
+    # "Proxy defects" [1.8, -1.72] --> used to compute primal gradient
+    assert torch.allclose(formulation.state()[0], mktensor([1.8 * 1e-2, 0.0]))
+
+    # ----------------------- Second iteration -----------------------
+    coop.zero_grad()
+    lagrangian = formulation.composite_objective(cmp.closure, params)
+
+    # Check loss, proxy and non-proxy defects after forward pass
+    assert torch.allclose(lagrangian, mktensor(1.3124))
+    assert torch.allclose(cmp.state.loss, mktensor(1.28))
+    assert torch.allclose(cmp.state.ineq_defect, mktensor([1.8, -1.8]))
+    assert torch.allclose(cmp.state.proxy_ineq_defect, mktensor([1.8, -1.72]))
+
+    # Check primal and dual gradients after backward. Dual gradient must match
+    # ineq_defect
+    formulation.custom_backward(lagrangian)
+    assert torch.allclose(params.grad, mktensor([-0.0162, -3.218]))
+    assert torch.allclose(formulation.state()[0].grad, cmp.state.ineq_defect)
+
+    # Must pass closrue again to compute constraints for alternating update
+    coop.step(cmp.closure, params)
+
+    assert torch.allclose(params, mktensor([8.1e-4, -0.6391]))
+    # Constraint violation at this point [1.6383, -1.63909936]
+    assert torch.allclose(formulation.state()[0], mktensor([0.034383, 0.0]))
+
+    if device == "cuda":
+        assert cmp.state.loss.is_cuda
+        assert cmp.state.ineq_defect.is_cuda

--- a/tests/test_alternating_update.py
+++ b/tests/test_alternating_update.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+"""Tests for Extrapolation optimizers."""
+
+import functools
+import pdb
+
+import pytest
+import testing_utils
+import torch
+
+# Import basic closure example from helpers
+import toy_2d_problem
+
+import cooper
+
+
+def prepare_problem(aim_device, alternating):
+    device, skip = testing_utils.get_device_skip(aim_device, torch.cuda.is_available())
+
+    if skip.do_skip:
+        pytest.skip(skip.skip_reason)
+
+    params = torch.nn.Parameter(torch.tensor([0.0, -1.0], device=device))
+
+    try:
+        optimizer_class = getattr(cooper.optim, "SGD")
+    except:
+        optimizer_class = getattr(torch.optim, "SGD")
+    primal_optimizer = optimizer_class([params], lr=1e-2)
+
+    dual_optimizer = cooper.optim.partial_optimizer(torch.optim.SGD, lr=1e-2)
+
+    cmp = toy_2d_problem.Toy2dCMP(use_ineq=True)
+    formulation = cooper.LagrangianFormulation(cmp)
+
+    coop = cooper.ConstrainedOptimizer(
+        formulation=formulation,
+        primal_optimizer=primal_optimizer,
+        dual_optimizer=dual_optimizer,
+        dual_restarts=False,
+        alternating=alternating,
+    )
+
+    # Helper function to instantiate tensors in correct device
+    mktensor = functools.partial(torch.tensor, device=device)
+
+    return params, cmp, coop, formulation, mktensor
+
+
+@pytest.mark.parametrize("aim_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("alternating", [True, False])
+def test_manual_alternating(aim_device, alternating):
+    """
+    Test first step of alternating vs non-alternating GDA updates on toy 2D problem.
+    """
+
+    params, cmp, coop, formulation, mktensor = prepare_problem(aim_device, alternating)
+
+    coop.zero_grad()
+    lagrangian = formulation.composite_objective(cmp.closure, params)
+
+    # Check loss, proxy and non-proxy defects after forward pass
+    assert torch.allclose(lagrangian, mktensor(2.0))
+    assert torch.allclose(cmp.state.loss, mktensor(2.0))
+    assert torch.allclose(cmp.state.ineq_defect, mktensor([2.0, -2.0]))
+    assert cmp.state.eq_defect is None
+
+    # Multiplier initialization
+    assert torch.allclose(formulation.state()[0], mktensor([0.0, 0.0]))
+    assert formulation.state()[1] is None
+
+    # Check primal and dual gradients after backward. Dual gradient must match
+    # ineq_defect
+    formulation.custom_backward(lagrangian)
+    assert torch.allclose(params.grad, mktensor([0.0, -4.0]))
+    assert torch.allclose(formulation.state()[0].grad, cmp.state.ineq_defect)
+
+    # # Check updated primal and dual variable values
+    coop.step(cmp.closure, params)
+    assert torch.allclose(params, mktensor([0.0, -0.96]))
+
+    if alternating:
+        # Loss and violation measurements taken the initialization point [0, -0.96]
+        assert torch.allclose(cmp.state.loss, mktensor([1.8432]))
+        # The constraint defects are [1.96, -1.96]
+        assert torch.allclose(formulation.state()[0], mktensor([1.96 * 1e-2, 0.0]))
+    else:
+        # Loss and violation measurements taken the initialization point [0, -1]
+        assert torch.allclose(cmp.state.loss, mktensor([2.0]))
+        # In this case the defects are [2., -2.]
+        assert torch.allclose(formulation.state()[0], mktensor([2.0 * 1e-2, 0.0]))
+
+
+@pytest.mark.parametrize("aim_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("alternating", [True])
+def test_convergence_alternating(aim_device, alternating):
+    """
+    Test convergence of alternating GDA updates on toy 2D problem.
+    """
+
+    params, cmp, coop, formulation, mktensor = prepare_problem(aim_device, alternating)
+
+    for step_id in range(1500):
+        coop.zero_grad()
+
+        # When using the unconstrained formulation, lagrangian = loss
+        lagrangian = formulation.composite_objective(cmp.closure, params)
+        formulation.custom_backward(lagrangian)
+
+        # Need to pass closure to step function to perform alternating updates
+        coop.step(cmp.closure, params)
+
+    assert torch.allclose(params[0], torch.tensor(2.0 / 3.0))
+    assert torch.allclose(params[1], torch.tensor(1.0 / 3.0))


### PR DESCRIPTION
Closes #21 

## Changes

* Enable support for alternating gradient descent-ascent updates
* Enable use of proxy constraints with alternating updates

## Testing

* "Pen-and-paper" tests for correctness of alternating updates in toy problem for few iterations
* "Pen-and-paper" tests for correctness of alternating updates _with proxy constraints_ in toy problem for few iterations
* Ensure "asymptotic" convergence to the solution when using alternating updates on toy problem

## Untested

* I did not include a test of alternating updates with dual restarts. Current code raises a warning whenever these two options are used together. (Too many different settings; starting to become "combinatorial".)