### PR TITLE
Loading of dual_scheduler form checkpoint

### DIFF
--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -488,7 +488,7 @@ class ConstrainedOptimizer:
                         "State dict contains dual_scheduler_state but dual_scheduler is None."
                     )
 
-                dual_scheduler = dual_scheduler(dual_optimizer)
+                dual_scheduler = dual_scheduler_class(dual_optimizer)
                 dual_scheduler.load_state_dict(const_optim_state.dual_scheduler_state)
             else:
                 dual_scheduler = None


### PR DESCRIPTION
Closes #43 

## Changes

Bug fixed. This PR does:
https://github.com/cooper-org/cooper/blob/e6e732b0f06fcb3a1595c7d5dee6707d659fb130/cooper/constrained_optimizer.py#L491

The loading of a `dual_scheduler` from a checkpoint used to be a blind spot for tests. 
This PR considers this feature in the tests.

## Testing

`test_checkpointing.py` now considers the saving and loading a `dual_scheduler` (`torch.optim.lr_scheduler.StepLR`). 

