### PR TITLE
Multiple Primal Optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ primal_optimizer = cooper.optim.ExtraSGD([probs], lr=3e-2, momentum=0.7)
 dual_optimizer = cooper.optim.partial_optimizer(cooper.optim.ExtraSGD, lr=9e-3, momentum=0.7)
 
 # Wrap the formulation and both optimizers inside a ConstrainedOptimizer
-constrained_optimizer = cooper.ConstrainedOptimizer(formulation, primal_optimizer, dual_optimizer)
+constrained_optimizer = cooper.ConstrainedOptimizer(formulation, [primal_optimizer], dual_optimizer)
 
 # Here is the actual training loop.
 # The steps follow closely the `loss -> backward -> step` Pytorch workflow.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ primal_optimizer = cooper.optim.ExtraSGD([probs], lr=3e-2, momentum=0.7)
 dual_optimizer = cooper.optim.partial_optimizer(cooper.optim.ExtraSGD, lr=9e-3, momentum=0.7)
 
 # Wrap the formulation and both optimizers inside a ConstrainedOptimizer
-constrained_optimizer = cooper.ConstrainedOptimizer(formulation, [primal_optimizer], dual_optimizer)
-
+constrained_optimizer = cooper.ConstrainedOptimizer(formulation, primal_optimizer, dual_optimizer)
 # Here is the actual training loop.
 # The steps follow closely the `loss -> backward -> step` Pytorch workflow.
 for iter_num in range(5000):

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -242,8 +242,6 @@ class ConstrainedOptimizer:
                 non-extrapolating optimizer instead."""
             )
 
-        # self.is_extrapolation is set above depending on the whether the primal
-        # optimizers have an extrapolation function.
         if self.is_extrapolation != hasattr(self.dual_optimizer, "extrapolation"):
             raise RuntimeError(
                 """Primal and dual optimizers do not agree on whether to use

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -23,16 +23,16 @@ from .utils import validate_state_dicts
 @dataclass
 class ConstrainedOptimizerState:
     """Represents the "state" of a Constrained Optimizer in terms of the state
-    dicts of the primal optimizer, as well as those of the dual optimizer and
+    dicts of the primal optimizers, as well as those of the dual optimizer and
     the dual scheduler if applicable. This is used for checkpointing.
 
     # TODO(JGP): Add docs about difference between this and FormulationState
     # here we focus on the optimizers, while the formulation contains dual vars.
 
     Args:
-        primal_optimizer_state: State dict for the primal optimizer.
+        primal_optimizer_states: State dict for the primal optimizers.
         dual_optimizer_state: State dict for the dual optimizer.
-        dual_scheduler_state: State dict for the primal optimizer.
+        dual_scheduler_state: State dict for the dual scheduler.
     """
 
     primal_optimizer_states: List[Dict]
@@ -71,9 +71,10 @@ class ConstrainedOptimizer:
     Optimizes a :py:class:`~cooper.problem.ConstrainedMinimizationProblem`
     given its :py:class:`~cooper.problem.Formulation`.
 
-    A ``ConstrainedOptimizer`` includes one or two
-    :class:`torch.optim.Optimizer`\\s, for the primal and dual variables
-    associated with the ``Formulation``, respectively.
+    A ``ConstrainedOptimizer`` includes one or more
+    :class:`torch.optim.Optimizer`\\s for the primal variables and potentially
+    another :class:`torch.optim.Optimizer` for the dual variables
+    associated with the ``Formulation``.
 
     A ``ConstrainedOptimizer`` can be used on constrained or unconstrained
     ``ConstrainedMinimizationProblem``\\s. Please refer to the documentation
@@ -500,7 +501,7 @@ class ConstrainedOptimizer:
         primal_optimizer_states = const_optim_state.primal_optimizer_states
         if len(primal_optimizer_states) != len(primal_optimizers):
             raise ValueError(
-                """The number of primal optimizers does not match the  number of
+                """The number of primal optimizers does not match the number of
                 primal optimizer states."""
             )
 

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -305,11 +305,11 @@ class ConstrainedOptimizer:
             for primal_optimizer in self.primal_optimizers:
                 # Store parameter copy and compute t+1/2 iterates
                 primal_optimizer.extrapolation()  # type: ignore
-                if self.cmp.is_constrained:
-                    # Call to dual_step flips sign of gradients, then triggers
-                    # call to dual_optimizer.extrapolation and projects dual
-                    # variables
-                    self.dual_step(call_extrapolation=True)
+            if self.cmp.is_constrained:
+                # Call to dual_step flips sign of gradients, then triggers
+                # call to dual_optimizer.extrapolation and projects dual
+                # variables
+                self.dual_step(call_extrapolation=True)
 
             # Zero gradients and recompute loss at t+1/2
             self.zero_grad()

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -86,9 +86,10 @@ class ConstrainedOptimizer:
         formulation: ``Formulation`` of the ``ConstrainedMinimizationProblem``
             to be optimized.
 
-        primal_optimizers: List of fully instantiated
-            ``torch.optim.Optimizer``\\s used to optimize the primal parameters
-            (e.g. model parameters).
+        primal_optimizers: Fully instantiated ``torch.optim.Optimizer``\\s used
+            to optimize the primal parameters (e.g. model parameters). The primal
+            parameters can be partitioned into multiple optimizers, in this case
+            ``primal_optimizers`` accepts a list of ``torch.optim.Optimizer``\\s.
 
         dual_optimizer: Partially instantiated ``torch.optim.Optimizer``
             used to optimize the dual variables (e.g. Lagrange multipliers).
@@ -182,8 +183,8 @@ class ConstrainedOptimizer:
         if any(is_extrapolation_list) and not all(is_extrapolation_list):
             raise RuntimeError(
                 """One of the primal optimizers has an extrapolation function
-                while another does not. Extrapolation on some of the primal
-                variables and not others is not supported."""
+                while another does not. Please ensure that all primal optimizers
+                agree on whether to perform extrapolation."""
             )
 
         # We assume that the dual_optimizer agrees with the primal_optimizers on
@@ -241,7 +242,7 @@ class ConstrainedOptimizer:
                 non-extrapolating optimizer instead."""
             )
 
-        # self.is_extrapolation is set to True above if all of the primal
+        # self.is_extrapolation is set above depending on the whether the primal
         # optimizers have an extrapolation function.
         if self.is_extrapolation != hasattr(self.dual_optimizer, "extrapolation"):
             raise RuntimeError(

--- a/cooper/constrained_optimizer.py
+++ b/cooper/constrained_optimizer.py
@@ -11,7 +11,7 @@ methods:
 import pdb
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Type
+from typing import Callable, Dict, List, Optional, Type, Union
 
 import torch
 
@@ -35,7 +35,7 @@ class ConstrainedOptimizerState:
         dual_scheduler_state: State dict for the primal optimizer.
     """
 
-    primal_optimizer_state: Dict
+    primal_optimizer_states: List[Dict]
     dual_optimizer_state: Optional[Dict] = None
     dual_scheduler_state: Optional[Dict] = None
     alternating: bool = False
@@ -54,7 +54,7 @@ class ConstrainedOptimizerState:
                 return False
 
         state_dict_names = [
-            "primal_optimizer_state",
+            "primal_optimizer_states",
             "dual_optimizer_state",
             "dual_scheduler_state",
         ]
@@ -85,8 +85,9 @@ class ConstrainedOptimizer:
         formulation: ``Formulation`` of the ``ConstrainedMinimizationProblem``
             to be optimized.
 
-        primal_optimizer: Fully instantiated ``torch.optim.Optimizer`` used
-            to optimize the primal parameters (e.g. model parameters).
+        primal_optimizers: List of fully instantiated
+            ``torch.optim.Optimizer``\\s used to optimize the primal parameters
+            (e.g. model parameters).
 
         dual_optimizer: Partially instantiated ``torch.optim.Optimizer``
             used to optimize the dual variables (e.g. Lagrange multipliers).
@@ -113,7 +114,7 @@ class ConstrainedOptimizer:
     def __init__(
         self,
         formulation: Formulation,
-        primal_optimizer: torch.optim.Optimizer,
+        primal_optimizers: Union[List[torch.optim.Optimizer], torch.optim.Optimizer],
         dual_optimizer: Optional[torch.optim.Optimizer] = None,
         dual_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         alternating: bool = False,
@@ -121,7 +122,11 @@ class ConstrainedOptimizer:
     ):
         self.formulation = formulation
         self.cmp = self.formulation.cmp
-        self.primal_optimizer = primal_optimizer
+
+        if isinstance(primal_optimizers, torch.optim.Optimizer):
+            primal_optimizers = [primal_optimizers]
+        self.primal_optimizers = primal_optimizers
+
         self.dual_optimizer = dual_optimizer
         self.dual_scheduler = dual_scheduler
 
@@ -136,12 +141,12 @@ class ConstrainedOptimizer:
 
         Raises:
             NotImplementedError: The ``Formulation`` has an augmented Lagrangian
-                coefficient and ``primal_optimizer`` has an ``extrapolation``
-                function. This is not supported because of possible unexpected
-                behavior.
-            RuntimeError: The ``primal_optimizer`` has an ``extrapolation``
-                function and ``alternating`` was set to True. Mixing
-                extrapolation and alternating updates is not supported.
+                coefficient and one of ``primal_optimizers`` has an
+                ``extrapolation`` function. This is not supported because of
+                possible unexpected behavior.
+            RuntimeError: One of the ``primal_optimizers`` has an
+                ``extrapolation`` function and ``alternating`` was set to True.
+                Mixing extrapolation and alternating updates is not supported.
             RuntimeError: a ``dual_optimizer`` was provided but the
                 ``ConstrainedMinimizationProblem`` of formulation was
                 unconstrained. There are no dual variables to optimize.
@@ -153,23 +158,38 @@ class ConstrainedOptimizer:
                 ``dual_optimizer`` was provided. Can not schedule the learning
                 rate of an unknown optimizer.
             RuntimeError: the considered ``ConstrainedMinimizationProblem`` is
-                unconstrained, but the provided ``primal_optimizer`` has an
-                ``extrapolation`` function. This is not supported because of
+                unconstrained, but one of the provided ``primal_optimizers`` has
+                an ``extrapolation`` function. This is not supported because of
                 unexpected behavior when using extrapolation to update the
                 primal parameters without any dual parameters.
-            RuntimeError: One of ``primal_optimizer`` or ``dual_optimizer`` has
-                an extrapolation function while the other does not.
-                Extrapolation on only one player is not supported.
+            RuntimeError: One of the ``primal_optimizers`` has an
+                ``extrapolation`` function while another does not. Extrapolation
+                on some of the primal variables and not others is not supported.
+            RuntimeError: The ``primal_optimizers`` have extrapolation
+                functions while the ``dual_optimizer`` does not. Alternatively,
+                the ``dual_optimizer`` has an extrapolation function while the
+                ``primal_optimizers`` do not. Extrapolation on only one player
+                is not supported.
         """
 
         is_alternating = self.alternating
         is_aug_lag = isinstance(self.formulation, AugmentedLagrangianFormulation)
 
-        # We assume that both optimizers agree on whether to use extrapolation
-        # or not, so we use the primal optimizer as reference for deciding
-        # whether to use extrapolation. See check below for matching
-        # extrapolation behavior.
-        self.is_extrapolation = hasattr(self.primal_optimizer, "extrapolation")
+        is_extrapolation_list = [
+            hasattr(_, "extrapolation") for _ in self.primal_optimizers
+        ]
+        if any(is_extrapolation_list) and not all(is_extrapolation_list):
+            raise RuntimeError(
+                """One of the primal optimizers has an extrapolation function
+                while another does not. Extrapolation on some of the primal
+                variables and not others is not supported."""
+            )
+
+        # We assume that the dual_optimizer agrees with the primal_optimizers on
+        # whether to use extrapolation or not, so we use the primal_optimizers
+        # as reference for setting self.is_extrapolation. See check below for
+        # a matching extrapolation check.
+        self.is_extrapolation = any(is_extrapolation_list)
 
         if is_aug_lag:
             assert (
@@ -220,9 +240,9 @@ class ConstrainedOptimizer:
                 non-extrapolating optimizer instead."""
             )
 
-        if hasattr(self.primal_optimizer, "extrapolation") != hasattr(
-            self.dual_optimizer, "extrapolation"
-        ):
+        # self.is_extrapolation is set to True above if all of the primal
+        # optimizers have an extrapolation function.
+        if self.is_extrapolation != hasattr(self.dual_optimizer, "extrapolation"):
             raise RuntimeError(
                 """Primal and dual optimizers do not agree on whether to use
                 extrapolation or not."""
@@ -281,12 +301,14 @@ class ConstrainedOptimizer:
         ), "At least one of closure or defect_fn must be provided for alternating updates"
 
         if self.is_extrapolation:
-            # Store parameter copy and compute t+1/2 iterates
-            self.primal_optimizer.extrapolation()  # type: ignore
-            if self.cmp.is_constrained:
-                # Call to dual_step flips sign of gradients, then triggers call
-                # to dual_optimizer.extrapolation and projects dual variables
-                self.dual_step(call_extrapolation=True)
+            for primal_optimizer in self.primal_optimizers:
+                # Store parameter copy and compute t+1/2 iterates
+                primal_optimizer.extrapolation()  # type: ignore
+                if self.cmp.is_constrained:
+                    # Call to dual_step flips sign of gradients, then triggers
+                    # call to dual_optimizer.extrapolation and projects dual
+                    # variables
+                    self.dual_step(call_extrapolation=True)
 
             # Zero gradients and recompute loss at t+1/2
             self.zero_grad()
@@ -303,14 +325,16 @@ class ConstrainedOptimizer:
 
             # After this, the calls to `step` will update the stored copies with
             # the newly computed gradients
-            self.primal_optimizer.step()
+            for primal_optimizer in self.primal_optimizers:
+                primal_optimizer.step()
             if self.cmp.is_constrained:
                 self.dual_step()
 
         else:
             # Non-extrapolation case
 
-            self.primal_optimizer.step()
+            for primal_optimizer in self.primal_optimizers:
+                primal_optimizer.step()
 
             if self.cmp.is_constrained:
 
@@ -349,7 +373,8 @@ class ConstrainedOptimizer:
         # This is not a problem since we only need to compute the gradient wrt
         # the multipliers.
         if isinstance(self.formulation, AugmentedLagrangianFormulation):
-            # Use LR of dual optimizer as penalty coefficient for the augmented Lagrangian
+            # Use LR of dual optimizer as penalty coefficient for the augmented
+            # Lagrangian
             _ = self.formulation.composite_objective(
                 closure=None,
                 aug_lag_coeff_scheduler=self.dual_scheduler,
@@ -414,7 +439,8 @@ class ConstrainedOptimizer:
         """
 
         if not ignore_primal:
-            self.primal_optimizer.zero_grad()
+            for primal_optimizer in self.primal_optimizers:
+                primal_optimizer.zero_grad()
 
         if not ignore_dual:
 
@@ -432,7 +458,7 @@ class ConstrainedOptimizer:
         :py:class:`~cooper.constrained_optimizer.ConstrainedOptimizerState`.
         """
 
-        primal_optimizer_state = self.primal_optimizer.state_dict()
+        primal_optimizer_states = [_.state_dict() for _ in self.primal_optimizers]
 
         if self.dual_optimizer is not None:
             dual_optimizer_state = self.dual_optimizer.state_dict()
@@ -445,7 +471,7 @@ class ConstrainedOptimizer:
             dual_scheduler_state = None
 
         return ConstrainedOptimizerState(
-            primal_optimizer_state=primal_optimizer_state,
+            primal_optimizer_states=primal_optimizer_states,
             dual_optimizer_state=dual_optimizer_state,
             dual_scheduler_state=dual_scheduler_state,
             alternating=self.alternating,
@@ -457,7 +483,7 @@ class ConstrainedOptimizer:
         cls,
         const_optim_state: ConstrainedOptimizerState,
         formulation: Formulation,
-        primal_optimizer: torch.optim.Optimizer,
+        primal_optimizers: Union[List[torch.optim.Optimizer], torch.optim.Optimizer],
         dual_optimizer_class: Type[torch.optim.Optimizer] = None,
         dual_scheduler_class: Type[torch.optim.lr_scheduler._LRScheduler] = None,
     ):
@@ -468,7 +494,18 @@ class ConstrainedOptimizer:
             state_dict: state of the ConstrainedOptimizer.
         """
 
-        primal_optimizer.load_state_dict(const_optim_state.primal_optimizer_state)
+        if isinstance(primal_optimizers, torch.optim.Optimizer):
+            primal_optimizers = [primal_optimizers]
+
+        primal_optimizer_states = const_optim_state.primal_optimizer_states
+        if len(primal_optimizer_states) != len(primal_optimizers):
+            raise ValueError(
+                """The number of primal optimizers does not match the  number of
+                primal optimizer states."""
+            )
+
+        for optimizer, state in zip(primal_optimizers, primal_optimizer_states):
+            optimizer.load_state_dict(state)
 
         if const_optim_state.dual_optimizer_state is not None:
             if dual_optimizer_class is None:
@@ -499,7 +536,7 @@ class ConstrainedOptimizer:
 
         return ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizer=primal_optimizer,
+            primal_optimizers=primal_optimizers,
             dual_optimizer=dual_optimizer,
             dual_scheduler=dual_scheduler,
             alternating=const_optim_state.alternating,

--- a/cooper/utils.py
+++ b/cooper/utils.py
@@ -48,12 +48,9 @@ def validate_state_dicts(model_state_dict_1, model_state_dict_2):
         return False
 
     if isinstance(model_state_dict_1, list) and isinstance(model_state_dict_2, list):
-        return all(
-            [
-                validate_state_dicts(ii, jj)
-                for ii, jj in zip(model_state_dict_1, model_state_dict_2)
-            ]
-        )
+        zipped_dicts = zip(model_state_dict_1, model_state_dict_2)
+        is_each_valid = [validate_state_dicts(ii, jj) for ii, jj in zipped_dicts]
+        return all(is_each_valid)
 
     # Replicate modules have "module" attached to their keys, so strip these off when comparing to local model.
     if next(iter(model_state_dict_1.keys())).startswith("module"):

--- a/cooper/utils.py
+++ b/cooper/utils.py
@@ -47,6 +47,14 @@ def validate_state_dicts(model_state_dict_1, model_state_dict_2):
         )
         return False
 
+    if isinstance(model_state_dict_1, list) and isinstance(model_state_dict_2, list):
+        return all(
+            [
+                validate_state_dicts(ii, jj)
+                for ii, jj in zip(model_state_dict_1, model_state_dict_2)
+            ]
+        )
+
     # Replicate modules have "module" attached to their keys, so strip these off when comparing to local model.
     if next(iter(model_state_dict_1.keys())).startswith("module"):
         model_state_dict_1 = {

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -26,7 +26,7 @@ variables. This two-stage process is handled by **Cooper** inside the
 
 .. math::
 
-    x_{t+1} &= \texttt{primal_optimizer_update} \left( x_{t}, \nabla_{x} \mathcal{L}_{c_t}(x, \lambda_t)|_{x=x_t} \right)\\
+    x_{t+1} &= \texttt{primal_optimizers_update} \left( x_{t}, \nabla_{x} \mathcal{L}_{c_t}(x, \lambda_t)|_{x=x_t} \right)\\
     \lambda_{t+1} &= \texttt{dual_optimizer_update} \left( \lambda_{t}, {\color{red} \mathbf{-}} \nabla_{\lambda} \mathcal{L}({\color{red} x_{t+1}}, \lambda)|_{\lambda=\lambda_t} \right)
 
 
@@ -68,7 +68,7 @@ precision, **Cooper** implements a version of the Augmented Lagrangian method
 where the primal variables are updated using a gradient-based step.
 
 .. math::
-    x_{t+1} = \texttt{primal_optimizer_update} \left( x_{t}, \nabla_{x} \mathcal{L}_{c_t}(x, \lambda_t)|_{x=x_t} \right)
+    x_{t+1} = \texttt{primal_optimizers_update} \left( x_{t}, \nabla_{x} \mathcal{L}_{c_t}(x, \lambda_t)|_{x=x_t} \right)
 
 The new primal variables are then used to perform an
 :ref:`alternating update<alternating_updates>` on the Lagrange multipliers.

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -138,7 +138,7 @@ Example
 
     constrained_optimizer = cooper.ConstrainedOptimizer(
         formulation=formulation,
-        primal_optimizer=primal_optimizer,
+        primal_optimizers=[primal_optimizer],
         dual_optimizer=dual_optimizer,
         dual_scheduler=dual_scheduler,
         dual_restarts=False,

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -138,7 +138,7 @@ Example
 
     constrained_optimizer = cooper.ConstrainedOptimizer(
         formulation=formulation,
-        primal_optimizers=[primal_optimizer],
+        primal_optimizers=primal_optimizer,
         dual_optimizer=dual_optimizer,
         dual_scheduler=dual_scheduler,
         dual_restarts=False,
@@ -224,3 +224,21 @@ constraint was being violated in the past.
 .. warning::
     The behavior of dual restarts has only been tested using
     :py:class:`~cooper.DenseMultiplier` objects.
+
+
+.. _multiple-primal_optimizers:
+
+Multiple primal optimizers
+--------------------------
+
+When constructing a :py:class:`~cooper.constrained_optimizer.ConstrainedOptimizer`,
+one or multiple primal optimizers (grouped in a list) can be provided. Allowing 
+for multiple primal optimizers is useful when setting separate groups of primal 
+variables to have different optimizer classes and hyperparameters.
+
+When a list of optimizers is provided for the ``primal_optimizers`` argument, they are
+treated "as if they were a single optimizer". In particular, all primal optimizers 
+operations such as :py:meth:`optimizer.step()<torch.optim.Optimizer.step>` are 
+executed simultaneously (without intermediate calls to
+:py:meth:`cmp.closure()<cooper.problem.ConstrainedMinimizationProblem.closure>` or
+:py:meth:`formulation.custom_backward(lagrangian)<cooper.problem.Formulation.custom_backward>`).

--- a/docs/source/constrained_optimizer.rst
+++ b/docs/source/constrained_optimizer.rst
@@ -31,8 +31,9 @@ The main ingredients to build a ``ConstrainedOptimizer`` are a
 
 .. note::
     **Cooper** supports the use of multiple ``primal_optimizers``, each
-    corresponding to different groups of primal variables. See
-    :ref:`multiple-primal_optimizers`.
+    corresponding to different groups of primal variables. The
+    ``primal_optimizers`` argument accepts a single optimizer, or a list
+    of optimizers. See :ref:`multiple-primal_optimizers`.
 
 If the ``ConstrainedMinimizationProblem`` you are dealing with is in fact
 constrained, depending on your formulation, you might also need to provide a
@@ -68,7 +69,7 @@ the definition of a CMP can be found under the entry for :ref:`cmp`.
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizers=[primal_optim],
+            primal_optimizers=primal_optimizer,
         )
 
 - **Constrained problem**
@@ -87,7 +88,7 @@ the definition of a CMP can be found under the entry for :ref:`cmp`.
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizers=[primal_optimizer],
+            primal_optimizers=primal_optimizer,
             dual_optimizer=dual_optimizer,
         )
 
@@ -129,7 +130,7 @@ Example
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizers=[primal_optimizer],
+            primal_optimizers=primal_optimizer,
             dual_optimizer=dual_optimizer,
         )
 

--- a/docs/source/constrained_optimizer.rst
+++ b/docs/source/constrained_optimizer.rst
@@ -27,7 +27,12 @@ Construction
 The main ingredients to build a ``ConstrainedOptimizer`` are a
 :py:class:`~cooper.problem.Formulation` (associated with a
 :py:class:`~cooper.problem.ConstrainedMinimizationProblem`) and a
-:py:class:`torch.optim.Optimizer` corresponding to the ``primal_optimizer``.
+:py:class:`torch.optim.Optimizer` corresponding to a ``primal_optimizer``.
+
+.. note::
+    **Cooper** supports the use of multiple ``primal_optimizers``, each
+    corresponding to different groups of primal variables. See
+    :ref:`multiple-primal_optimizers`.
 
 If the ``ConstrainedMinimizationProblem`` you are dealing with is in fact
 constrained, depending on your formulation, you might also need to provide a

--- a/docs/source/constrained_optimizer.rst
+++ b/docs/source/constrained_optimizer.rst
@@ -63,7 +63,7 @@ the definition of a CMP can be found under the entry for :ref:`cmp`.
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizer=primal_optim,
+            primal_optimizers=[primal_optim],
         )
 
 - **Constrained problem**
@@ -82,7 +82,7 @@ the definition of a CMP can be found under the entry for :ref:`cmp`.
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizer=primal_optimizer,
+            primal_optimizers=[primal_optimizer],
             dual_optimizer=dual_optimizer,
         )
 
@@ -124,7 +124,7 @@ Example
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizer=primal_optimizer,
+            primal_optimizers=[primal_optimizer],
             dual_optimizer=dual_optimizer,
         )
 
@@ -196,8 +196,9 @@ on the dual parameters, with simultaneous updates.
 .. note::
 
     When applied to an unconstrained problem, :py:meth:`ConstrainedOptimizer.step`
-    will be equivalent to performing ``primal_optimizer.step()`` based on the
-    gradient of the loss with respect to the primal parameters.
+    will be equivalent to performing ``optimizer.step()`` on all of the
+    ``primal_optimizers`` based on the gradient of the loss with respect to the
+    primal parameters.
 
 
 .. include:: additional_features.rst

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -3,23 +3,6 @@ Optim Module
 
 .. currentmodule:: cooper.optim
 
-
-.. _multiple-primal_optimizers:
-
-Multiple primal optimizers
---------------------------
-
-When constructing a :py:class:`~cooper.constrained_optimizer.ConstrainedOptimizer`,
-one or multiple primal optimizers can be provided. When a list of optimizers is provided
-for the ``primal_optimizers`` argument, they are all treated as if they were a single
-optimizer. In particular, every operation applied to one optimizer is
-simultaneously applied to the other primal, without intermediate calls to
-:py:meth:`cmp.closure()<cooper.problem.ConstrainedMinimizationProblem.closure>` or
-:py:meth:`formulation.custom_backward(lagrangian)<cooper.problem.Formulation.custom_backward>`.
-
-Allowing for multiple primal optimizers is useful when setting different groups of
-primal variables to have different optimizer classes and hyperparameters.
-
 .. _partial_optimizer_instantiation:
 
 Partial optimizer instantiation
@@ -117,7 +100,7 @@ extra-gradient in the context of solving Variational Inequality Problems.
 
         const_optim = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizers=[primal_optimizer],
+            primal_optimizers=primal_optimizer,
             dual_optimizer=dual_optimizer,
         )
 
@@ -168,7 +151,7 @@ for the learning rate schedulers.
         primal_scheduler = StepLR(primal_optimizer, step_size=1, gamma=0.1)
         dual_scheduler = cooper.optim.partial_scheduler(ExponentialLR, **scheduler_kwargs)
 
-        const_optim = cooper.ConstrainedOptimizer(..., [primal_optimizer], dual_optimizer, dual_scheduler)
+        const_optim = cooper.ConstrainedOptimizer(..., primal_optimizer, dual_optimizer, dual_scheduler)
 
         for step in range(num_steps):
             ...

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -99,7 +99,7 @@ extra-gradient in the context of solving Variational Inequality Problems.
 
         const_optim = cooper.ConstrainedOptimizer(
             formulation=formulation,
-            primal_optimizer=primal_optimizer,
+            primal_optimizers=[primal_optimizer],
             dual_optimizer=dual_optimizer,
         )
 
@@ -150,7 +150,7 @@ for the learning rate schedulers.
         primal_scheduler = StepLR(primal_optimizer, step_size=1, gamma=0.1)
         dual_scheduler = cooper.optim.partial_scheduler(ExponentialLR, **scheduler_kwargs)
 
-        const_optim = cooper.ConstrainedOptimizer(..., primal_optimizer, dual_optimizer, dual_scheduler)
+        const_optim = cooper.ConstrainedOptimizer(..., [primal_optimizer], dual_optimizer, dual_scheduler)
 
         for step in range(num_steps):
             ...
@@ -162,7 +162,7 @@ Primal learning rate scheduler
 
 .. _primal_lr_scheduler:
 
-You must instantiate the scheduler for the learning rate used by the
+You must instantiate the scheduler for the learning rate used by each
 ``primal_optimizer`` and call the scheduler's ``step`` method explicitly, as is
 usual in Pytorch. See :py:mod:`torch.optim.lr_scheduler` for details.
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -4,10 +4,28 @@ Optim Module
 .. currentmodule:: cooper.optim
 
 
+.. _multiple-primal_optimizers:
+
+Multiple primal optimizers
+--------------------------
+
+When constructing a :py:class:`~cooper.constrained_optimizer.ConstrainedOptimizer`,
+one or multiple primal optimizers can be provided. When a list of optimizers is provided
+for the ``primal_optimizers`` argument, they are all treated as if they were a single
+optimizer. In particular, every operation applied to one optimizer is
+simultaneously applied to the other primal, without intermediate calls to
+:py:meth:`cmp.closure()<cooper.problem.ConstrainedMinimizationProblem.closure>` or
+:py:meth:`formulation.custom_backward(lagrangian)<cooper.problem.Formulation.custom_backward>`.
+
+Allowing for multiple primal optimizers is useful when setting different groups of
+primal variables to have different optimizer classes and hyperparameters.
+
 .. _partial_optimizer_instantiation:
 
 Partial optimizer instantiation
 -------------------------------
+
+.. automethod:: cooper.optim.partial_optimizer
 
 When constructing a :py:class:`~cooper.constrained_optimizer.ConstrainedOptimizer`, the
 ``dual_optimizer`` parameter is expected to be a

--- a/tests/helpers/cooper_test_utils.py
+++ b/tests/helpers/cooper_test_utils.py
@@ -72,7 +72,7 @@ def build_test_problem(
 
     coop = cooper.ConstrainedOptimizer(
         formulation=formulation,
-        primal_optimizer=primal_optimizer,
+        primal_optimizers=[primal_optimizer],
         dual_optimizer=dual_optimizer,
         dual_scheduler=dual_scheduler,
         dual_restarts=dual_restarts,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -121,7 +121,7 @@ def test_checkpoint(aim_device, use_ineq):
     loaded_coop = cooper.ConstrainedOptimizer.load_from_state_dict(
         const_optim_state=coop_state_dict_100,
         formulation=loaded_formulation,
-        primal_optimizer=loaded_primal_optimizer,
+        primal_optimizers=[loaded_primal_optimizer],
         dual_optimizer_class=partial_dual_optim,
         dual_scheduler_class=None,
     )

--- a/tests/test_extrapolation.py
+++ b/tests/test_extrapolation.py
@@ -51,7 +51,7 @@ def test_extrapolation(aim_device, primal_optimizer_cls):
         assert cmp.state.eq_defect is None or cmp.state.eq_defect.is_cuda
         assert cmp.state.ineq_defect is None or cmp.state.ineq_defect.is_cuda
 
-    # TODO: Why do we need such relatex tolerance for this test to pass?
+    # TODO: Why do we need such relaxed tolerance for this test to pass?
     if primal_optimizer_cls == cooper.optim.ExtraSGD:
         atol = 1e-8
     else:

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -53,7 +53,7 @@ def test_lr_schedulers(aim_device, scheduler_name, optimizer_cls):
 
     params, cmp, coop, formulation, _, _ = test_problem_data.as_tuple()
 
-    # Only considering one primal_optimizer on this tests.
+    # Only considering one primal_optimizer on this test.
     primal_optimizer = coop.primal_optimizers[0]
     primal_scheduler = scheduler_class(primal_optimizer, **scheduler_kwargs)
 

--- a/tests/test_lr_schedulers.py
+++ b/tests/test_lr_schedulers.py
@@ -53,14 +53,16 @@ def test_lr_schedulers(aim_device, scheduler_name, optimizer_cls):
 
     params, cmp, coop, formulation, _, _ = test_problem_data.as_tuple()
 
-    primal_scheduler = scheduler_class(coop.primal_optimizer, **scheduler_kwargs)
+    # Only considering one primal_optimizer on this tests.
+    primal_optimizer = coop.primal_optimizers[0]
+    primal_scheduler = scheduler_class(primal_optimizer, **scheduler_kwargs)
 
     for step_id in range(7):
         coop.zero_grad()
         lagrangian = formulation.composite_objective(cmp.closure, params)
         formulation.custom_backward(lagrangian)
 
-        if hasattr(coop.primal_optimizer, "extrapolation"):
+        if hasattr(primal_optimizer, "extrapolation"):
             # Only one dual_scheduler step should be performed even if
             # extrapolation is used
             coop.step(cmp.closure, params)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -12,22 +12,29 @@ import cooper
 
 @pytest.mark.parametrize("aim_device", ["cpu", "cuda"])
 @pytest.mark.parametrize("use_ineq", [True, False])
-def test_toy_problem(aim_device, use_ineq):
+@pytest.mark.parametrize("multiple_optimizers", [True, False])
+def test_toy_problem(aim_device, use_ineq, multiple_optimizers):
     """
     Verify constrained and unconstrained executions run correctly on a toy 2D
     problem.
     """
+    if multiple_optimizers:
+        primal_optim_cls = [torch.optim.SGD, torch.optim.Adam]
+        primal_optim_kwargs = [{"lr": 1e-2, "momentum": 0.3}, {"lr": 1e-2}]
+    else:
+        primal_optim_cls = torch.optim.SGD
+        primal_optim_kwargs = {"lr": 1e-2, "momentum": 0.3}
 
     test_problem_data = cooper_test_utils.build_test_problem(
         aim_device=aim_device,
-        primal_optim_cls=torch.optim.SGD,
+        primal_optim_cls=primal_optim_cls,
         primal_init=[0.0, -1.0],
         dual_optim_cls=torch.optim.SGD,
         use_ineq=use_ineq,
         use_proxy_ineq=False,
         dual_restarts=True,
         alternating=False,
-        primal_optim_kwargs={"lr": 1e-2, "momentum": 0.3},
+        primal_optim_kwargs=primal_optim_kwargs,
         dual_optim_kwargs={"lr": 1e-2},
     )
 
@@ -52,4 +59,5 @@ def test_toy_problem(aim_device, use_ineq):
         assert torch.allclose(params[1], torch.tensor(1.0 / 3.0))
     else:
         # This unconstrained quadratic form has minimum at the origin
-        assert torch.allclose(params, torch.tensor(0.0))
+        assert torch.allclose(params[0], torch.tensor(0.0))
+        assert torch.allclose(params[1], torch.tensor(0.0))

--- a/tutorials/logistic_regression.ipynb
+++ b/tutorials/logistic_regression.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "coop = cooper.ConstrainedOptimizer(\n",
     "    formulation=formulation,\n",
-    "    primal_optimizer=primal_optimizer,\n",
+    "    primal_optimizers=[primal_optimizer],\n",
     "    dual_optimizer=dual_optimizer,\n",
     ")"
    ]

--- a/tutorials/max_entropy.ipynb
+++ b/tutorials/max_entropy.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "coop = cooper.ConstrainedOptimizer(\n",
     "    formulation=formulation,\n",
-    "    primal_optimizers=[primal_optimizer],\n",
+    "    primal_optimizers=primal_optimizer,\n",
     "    dual_optimizer=dual_optimizer,\n",
     ")"
    ]

--- a/tutorials/max_entropy.ipynb
+++ b/tutorials/max_entropy.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "coop = cooper.ConstrainedOptimizer(\n",
     "    formulation=formulation,\n",
-    "    primal_optimizer=primal_optimizer,\n",
+    "    primal_optimizers=[primal_optimizer],\n",
     "    dual_optimizer=dual_optimizer,\n",
     ")"
    ]

--- a/tutorials/scripts/plot_gaussian_mixture.py
+++ b/tutorials/scripts/plot_gaussian_mixture.py
@@ -170,7 +170,7 @@ def train(problem_name, inputs, targets, num_iters=5000, lr=1e-2, const_level=0.
 
     constrained_optimizer = cooper.ConstrainedOptimizer(
         formulation=formulation,
-        primal_optimizer=primal_optimizer,
+        primal_optimizers=[primal_optimizer],
         dual_optimizer=dual_optimizer,
     )
 

--- a/tutorials/scripts/plot_gaussian_mixture.py
+++ b/tutorials/scripts/plot_gaussian_mixture.py
@@ -170,7 +170,7 @@ def train(problem_name, inputs, targets, num_iters=5000, lr=1e-2, const_level=0.
 
     constrained_optimizer = cooper.ConstrainedOptimizer(
         formulation=formulation,
-        primal_optimizers=[primal_optimizer],
+        primal_optimizers=primal_optimizer,
         dual_optimizer=dual_optimizer,
     )
 

--- a/tutorials/scripts/plot_max_entropy.py
+++ b/tutorials/scripts/plot_max_entropy.py
@@ -65,7 +65,7 @@ dual_optimizer = cooper.optim.partial_optimizer(
 )
 
 # Wrap the formulation and both optimizers inside a ConstrainedOptimizer
-coop = cooper.ConstrainedOptimizer(formulation, [primal_optimizer], dual_optimizer)
+coop = cooper.ConstrainedOptimizer(formulation, primal_optimizer, dual_optimizer)
 
 state_history = cooper.StateLogger(save_metrics=["loss", "eq_defect", "eq_multipliers"])
 

--- a/tutorials/scripts/plot_max_entropy.py
+++ b/tutorials/scripts/plot_max_entropy.py
@@ -65,7 +65,7 @@ dual_optimizer = cooper.optim.partial_optimizer(
 )
 
 # Wrap the formulation and both optimizers inside a ConstrainedOptimizer
-coop = cooper.ConstrainedOptimizer(formulation, primal_optimizer, dual_optimizer)
+coop = cooper.ConstrainedOptimizer(formulation, [primal_optimizer], dual_optimizer)
 
 state_history = cooper.StateLogger(save_metrics=["loss", "eq_defect", "eq_multipliers"])
 

--- a/tutorials/widget.py
+++ b/tutorials/widget.py
@@ -281,7 +281,7 @@ class Toy2DWidget:
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=self.formulation,
-            primal_optimizer=primal_optimizer,
+            primal_optimizers=[primal_optimizer],
             dual_optimizer=dual_optimizer,
             dual_restarts=dual_restarts,
         )

--- a/tutorials/widget.py
+++ b/tutorials/widget.py
@@ -281,7 +281,7 @@ class Toy2DWidget:
 
         constrained_optimizer = cooper.ConstrainedOptimizer(
             formulation=self.formulation,
-            primal_optimizers=[primal_optimizer],
+            primal_optimizers=primal_optimizer,
             dual_optimizer=dual_optimizer,
             dual_restarts=dual_restarts,
         )


### PR DESCRIPTION
Closes #39 

## Changes

Parameter `primal_optimizer` of `ConstrainedOptimizer` renamed to `primal_optimizers`. It accepts either a (i) `torch.optim.Optimizer` or a (ii) *list* of Optimizers. **Behavior in case (i) is unchanged**.

Lines previously performing `constrained_optimizer.primal_optimizer.method()` have been replaced by `for primal_optimizer in constrained_optimizer.primal_optimizers; primal_optimizer.method()`. 
For instance, 

https://github.com/cooper-org/cooper/blob/4421115314e25386042cbd2c3731b03aa766f082/cooper/constrained_optimizer.py#L329-L330

Saving and loading of checkpoints was modified to allow for lists of primal optimizers.

⚠ **Warning** ⚠
This breaks backward compatibility when instantiating a `ConstrainedOptimizer` with keyword argument `primal_optimizer`.

## Testing

Toy2D testing of constrained and unconstrained execution included in `test_optimizer.py`.
Checkpointing test included in `test_checkpoint.py`

This functionality is not tested together with other optimization methods or formulations (Extragradient, Augmented Lagrangian, Proxy constraints).

## Docs

Note added in `constrained_optimizer.rst` indicating that functionality exists.
Small section added in `optim.rst` describing how to setup multiple primal optimizers and how **Cooper** handles them.
Docstrings and overall documentation updated to be general enough for multiple optimizers.
