### PR TITLE
Off the shelf Cooper

### DIFF
--- a/cooper/formulation/augmented_lagrangian.py
+++ b/cooper/formulation/augmented_lagrangian.py
@@ -25,7 +25,7 @@ class AugmentedLagrangianFormulation(LagrangianFormulation):
 
     def __init__(
         self,
-        cmp: ConstrainedMinimizationProblem,
+        cmp: Optional[ConstrainedMinimizationProblem] = None,
         ineq_init: Optional[torch.Tensor] = None,
         eq_init: Optional[torch.Tensor] = None,
     ):
@@ -146,8 +146,8 @@ class AugmentedLagrangianFormulation(LagrangianFormulation):
         else:
             cmp_state = closure(*closure_args, **closure_kwargs)
 
-        if write_state:
-            self.cmp.state = cmp_state
+        if write_state and self.cmp is not None:
+            self.write_cmp_state(cmp_state)
 
         # Extract values from ProblemState object
         loss = cmp_state.loss

--- a/cooper/formulation/augmented_lagrangian.py
+++ b/cooper/formulation/augmented_lagrangian.py
@@ -104,7 +104,7 @@ class AugmentedLagrangianFormulation(LagrangianFormulation):
         closure: Callable[..., CMPState] = None,
         *closure_args,
         pre_computed_state: Optional[CMPState] = None,
-        write_state: bool = True,
+        write_state: Optional[bool] = True,
         **closure_kwargs
     ) -> torch.Tensor:
         """

--- a/cooper/formulation/formulation.py
+++ b/cooper/formulation/formulation.py
@@ -72,7 +72,7 @@ class Formulation(abc.ABC):
         `ConstrainedMinimizationProblem`, writes a CMPState to the CMP."""
 
         if self.cmp is None:
-            raise ValueError(
+            raise RuntimeError(
                 """Cannot write state to a formulation which is not linked to a
                 ConstrainedMinimizationProblem"""
             )
@@ -131,7 +131,7 @@ class UnconstrainedFormulation(Formulation):
         self,
         closure: Callable[..., CMPState],
         *closure_args,
-        write_state: bool = True,
+        write_state: Optional[bool] = True,
         **closure_kwargs
     ) -> torch.Tensor:
         """

--- a/cooper/formulation/lagrangian.py
+++ b/cooper/formulation/lagrangian.py
@@ -240,7 +240,7 @@ class LagrangianFormulation(BaseLagrangianFormulation):
         closure: Callable[..., CMPState] = None,
         *closure_args,
         pre_computed_state: Optional[CMPState] = None,
-        write_state: bool = True,
+        write_state: Optional[bool] = True,
         **closure_kwargs
     ) -> torch.Tensor:
         """

--- a/cooper/formulation/lagrangian.py
+++ b/cooper/formulation/lagrangian.py
@@ -28,7 +28,7 @@ class BaseLagrangianFormulation(Formulation, metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        cmp: ConstrainedMinimizationProblem,
+        cmp: Optional[ConstrainedMinimizationProblem] = None,
         ineq_init: Optional[torch.Tensor] = None,
         eq_init: Optional[torch.Tensor] = None,
     ):
@@ -281,8 +281,8 @@ class LagrangianFormulation(BaseLagrangianFormulation):
         else:
             cmp_state = closure(*closure_args, **closure_kwargs)
 
-        if write_state:
-            self.cmp.state = cmp_state
+        if write_state and self.cmp is not None:
+            self.write_cmp_state(cmp_state)
 
         # Extract values from ProblemState object
         loss = cmp_state.loss

--- a/cooper/optim/constrained_optimizers/alternating_optimizer.py
+++ b/cooper/optim/constrained_optimizers/alternating_optimizer.py
@@ -23,7 +23,6 @@ class AlternatingConstrainedOptimizer(ConstrainedOptimizer):
         dual_restarts: bool = False,
     ):
         self.formulation = formulation
-        self.cmp = self.formulation.cmp
 
         if isinstance(primal_optimizers, torch.optim.Optimizer):
             self.primal_optimizers = [primal_optimizers]

--- a/cooper/optim/constrained_optimizers/extrapolation_optimizer.py
+++ b/cooper/optim/constrained_optimizers/extrapolation_optimizer.py
@@ -56,7 +56,6 @@ class ExtrapolationConstrainedOptimizer(ConstrainedOptimizer):
         dual_restarts: bool = False,
     ):
         self.formulation = formulation
-        self.cmp = self.formulation.cmp
 
         if isinstance(primal_optimizers, ExtragradientOptimizer):
             self.primal_optimizers = [primal_optimizers]

--- a/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
+++ b/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
@@ -50,12 +50,11 @@ class SimultaneousConstrainedOptimizer(ConstrainedOptimizer):
         self,
         formulation: Formulation,
         primal_optimizers: Union[List[torch.optim.Optimizer], torch.optim.Optimizer],
-        dual_optimizer: Optional[torch.optim.Optimizer] = None,
+        dual_optimizer: torch.optim.Optimizer,
         dual_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         dual_restarts: bool = False,
     ):
         self.formulation = formulation
-        self.cmp = self.formulation.cmp
 
         if isinstance(primal_optimizers, torch.optim.Optimizer):
             self.primal_optimizers = [primal_optimizers]

--- a/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
+++ b/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
@@ -50,7 +50,7 @@ class SimultaneousConstrainedOptimizer(ConstrainedOptimizer):
         self,
         formulation: Formulation,
         primal_optimizers: Union[List[torch.optim.Optimizer], torch.optim.Optimizer],
-        dual_optimizer: torch.optim.Optimizer,
+        dual_optimizer: Optional[torch.optim.Optimizer] = None,
         dual_scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         dual_restarts: bool = False,
     ):

--- a/cooper/optim/unconstrained_optimizer.py
+++ b/cooper/optim/unconstrained_optimizer.py
@@ -36,7 +36,6 @@ class UnconstrainedOptimizer(CooperOptimizer):
             )
 
         self.formulation = formulation
-        self.cmp = self.formulation.cmp
 
         if isinstance(primal_optimizers, torch.optim.Optimizer):
             self.primal_optimizers = [primal_optimizers]

--- a/tests/test_simplest_pipeline.py
+++ b/tests/test_simplest_pipeline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""Tests for Constrained Optimizer class. This test already verifies that the
+code behaves as expected for an unconstrained setting."""
+
+import pytest
+import torch
+
+import cooper
+
+
+@pytest.fixture()
+def params():
+    return torch.nn.Parameter(torch.tensor([0.0, -1.0]))
+
+
+@pytest.fixture()
+def formulation():
+    return cooper.LagrangianFormulation()
+
+
+@pytest.fixture()
+def constrained_optimizer(params, formulation):
+    primal_optim = torch.optim.SGD([params], lr=1e-2, momentum=0.3)
+    dual_optim = cooper.optim.partial_optimizer(torch.optim.SGD, lr=1e-2)
+
+    return cooper.SimultaneousConstrainedOptimizer(
+        formulation, primal_optim, dual_optim, dual_restarts=True
+    )
+
+
+def loss_fn(params):
+    param_x, param_y = params
+
+    return param_x**2 + 2 * param_y**2
+
+
+def defect_fn(params):
+
+    param_x, param_y = params
+
+    # Two inequality constraints
+    defect = torch.stack(
+        [
+            -param_x - param_y + 1.0,  # x + y \ge 1
+            param_x**2 + param_y - 1.0,  # x**2 + y \le 1.0
+        ]
+    )
+
+    return defect
+
+
+def test_simplest_pipeline(params, formulation, constrained_optimizer):
+
+    for step_id in range(1500):
+        constrained_optimizer.zero_grad()
+
+        loss = loss_fn(params)
+        defect = defect_fn(params)
+
+        # Create a CMPState object to hold the loss and defect values
+        cmp_state = cooper.CMPState(loss=loss, ineq_defect=defect)
+
+        lagrangian = formulation.composite_objective(pre_computed_state=cmp_state)
+        formulation.custom_backward(lagrangian)
+
+        constrained_optimizer.step()
+
+    assert torch.allclose(params[0], torch.tensor(2.0 / 3.0))
+    assert torch.allclose(params[1], torch.tensor(1.0 / 3.0))


### PR DESCRIPTION
Addresses #55 

## Changes

* Passing a CMP when constructing a formulation is now optional
* Constrained Optimizers no longer hold a `self.cmp` attribute
* When no CMP is provided to the formulation, the user _must_ provide `pre_computed_state` when calling `formulation.composite_objective` method of the formulation. 
* `write_state` parameter of `formulation.composite_objective` is a no-op when `formulation.cmp` is `None`

## Testing

A toy test was implemented (`tests/test_simplest_pipeline.py`) without a CMP or closure. This considers inequality constraints (not proxy) and a SimultaneousConstrainedOptimizer.

Extrapolation and Alternating updates without a CMP are untested. Nonetheless, if a `closure` is provided to their `step()` method, they should work.

This is NOT breaking backwards compatibility. It is an alternative way for the user to use Cooper, but creating a CMP with a closure is still supported.

## Docs
The changes in this PR have not been documented. Documentation is currently lagging behind code in dev branch (#53 #29). 
I think that we could tackle all the issues with documentation in one go. For now, I propose to consider this PR without docs.