### PR TITLE
Remove formulation usage in StateLogger

### DIFF
--- a/cooper/utils/state_logger.py
+++ b/cooper/utils/state_logger.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from typing import List
 
-from cooper.formulation import Formulation
+from cooper.problem import CMPState
 
 
 class StateLogger:
@@ -22,7 +22,7 @@ class StateLogger:
 
     def store_metrics(
         self,
-        formulation: Formulation,
+        cmp_state: CMPState,
         step_id: int,
         partial_dict: dict = None,
     ):
@@ -30,8 +30,7 @@ class StateLogger:
         Store a new screenshot of the metrics.
 
         Args:
-            formulation: Formulation from which to take the current metric
-                values.
+            cmp_state: State of the CMP to be stored.
             step_id: Identifier for the optimization step.
             partial_dict: Auxiliary dictionary with other metrics to be logged,
                 but which are not part of the "canonical" options available in
@@ -41,15 +40,11 @@ class StateLogger:
 
         for metric in self.save_metrics:
             if metric == "loss":
-                aux_dict[metric] = formulation.cmp.state.loss.item()
+                aux_dict[metric] = cmp_state.loss.item()
             elif metric == "ineq_defect":
-                aux_dict[metric] = deepcopy(formulation.cmp.state.ineq_defect.data)
+                aux_dict[metric] = deepcopy(cmp_state.ineq_defect.data)
             elif metric == "eq_defect":
-                aux_dict[metric] = deepcopy(formulation.cmp.state.eq_defect.data)
-            elif metric == "ineq_multipliers":
-                aux_dict[metric] = deepcopy(formulation.state()[0].data)
-            elif metric == "eq_multipliers":
-                aux_dict[metric] = deepcopy(formulation.state()[1].data)
+                aux_dict[metric] = deepcopy(cmp_state.eq_defect.data)
 
         if partial_dict is not None:
             aux_dict.update(partial_dict)

--- a/tutorials/scripts/plot_max_entropy.py
+++ b/tutorials/scripts/plot_max_entropy.py
@@ -79,8 +79,19 @@ for iter_num in range(2000):
     coop.step(cmp.closure, probs)
 
     # Store optimization metrics at each step
-    partial_dict = {"params": copy.deepcopy(probs.data)}
-    state_history.store_metrics(formulation, iter_num, partial_dict)
+    partial_dict = {
+        "params": copy.deepcopy(probs.data),
+        "ineq_multipliers": copy.deepcopy(formulation.state()[0].data),
+        "eq_multipliers": copy.deepcopy(formulation.state()[1].data),
+    }
+
+    # Store optimization metrics at each step
+    state_history.store_metrics(
+        cmp_state=cmp.state,
+        step_id=iter_num,
+        partial_dict=partial_dict,
+    )
+
 
 all_metrics = state_history.unpack_stored_metrics()
 

--- a/tutorials/widget.py
+++ b/tutorials/widget.py
@@ -307,11 +307,17 @@ class Toy2DWidget:
             params[:, 0].data.clamp_(min=0, max=np.pi / 2)
             params[:, 1].data.clamp_(min=0, max=3)
 
+            partial_dict = {
+                "params": copy.deepcopy(params.data),
+                "ineq_multipliers": copy.deepcopy(self.formulation.state()[0].data),
+                "eq_multipliers": copy.deepcopy(self.formulation.state()[1].data),
+            }
+
             # Store optimization metrics at each step
             state_history.store_metrics(
-                self.formulation,
-                iter_num,
-                partial_dict={"params": copy.deepcopy(params.data)},
+                cmp_state=self.cmp.state,
+                step_id=iter_num,
+                partial_dict=partial_dict,
             )
 
         return state_history


### PR DESCRIPTION
Co-authored-by: Juan Camilo Ramirez <juan43.ramirez@gmail.com>

Closes #61

## Changes

- Remove use of `formulation` in call to `store_metrics` method of `StateLogger`.