### PR TITLE
Missing formulation import in __init__

### DIFF
--- a/cooper/__init__.py
+++ b/cooper/__init__.py
@@ -16,6 +16,7 @@ except PackageNotFoundError:
     warnings.warn("Could not retrieve cooper version!")
 
 from cooper.formulation import (
+    AugmentedLagrangianFormulation,
     Formulation,
     LagrangianFormulation,
     UnconstrainedFormulation,


### PR DESCRIPTION
Closes #65 

## Changes

Fixed missing import of `AugmentedLagrangianFormulation` in root `__init__` file.

## Testing

All pre-existing tests passing.