### PR TITLE
#49 Require `maximize=True` for dual optimizers

### DIFF
--- a/cooper/multipliers/multipliers.py
+++ b/cooper/multipliers/multipliers.py
@@ -109,13 +109,12 @@ class DenseMultiplier(BaseMultiplier):
 
         assert self.positive, "Restarts is only supported for inequality multipliers"
 
-        # Call to formulation.backwards has already flipped sign
-        # A currently *positive* gradient means original defect is negative, so
-        # the constraint is being satisfied.
+        # A *negative* gradient means that the constraint violation is negative,
+        # so the constraint is being satisfied.
 
         # The code below still works in the case of proxy constraints, since the
         # multiplier updates are computed based on *non-proxy* constraints
-        feasible_filter = self.weight.grad > 0
+        feasible_filter = self.weight.grad < 0
         self.weight.grad[feasible_filter] = 0.0
         self.weight.data[feasible_filter] = 0.0
 

--- a/cooper/optim/constrained_optimizers/alternating_optimizer.py
+++ b/cooper/optim/constrained_optimizers/alternating_optimizer.py
@@ -131,13 +131,6 @@ class AlternatingConstrainedOptimizer(ConstrainedOptimizer):
 
     def dual_step(self):
 
-        # Flip gradients for multipliers to perform ascent.
-        # We only do the flipping *right before* applying the optimizer step to
-        # avoid accidental double sign flips.
-        for multiplier in self.formulation.state():
-            if multiplier is not None:
-                multiplier.grad.mul_(-1.0)
-
         # Update multipliers based on current constraint violations (gradients)
         self.dual_optimizer.step()
 

--- a/cooper/optim/constrained_optimizers/constrained_optimizer.py
+++ b/cooper/optim/constrained_optimizers/constrained_optimizer.py
@@ -87,7 +87,9 @@ class ConstrainedOptimizer(CooperOptimizer):
         assert self.dual_optimizer is not None and callable(self.dual_optimizer)
 
         # Checks if needed and instantiates dual_optimizer
-        self.dual_optimizer = self.dual_optimizer(self.formulation.dual_parameters)
+        self.dual_optimizer = self.dual_optimizer(
+            self.formulation.dual_parameters, maximize=True
+        )
 
         if self.dual_scheduler is not None:
             assert callable(self.dual_scheduler), "dual_scheduler must be callable"

--- a/cooper/optim/constrained_optimizers/extrapolation_optimizer.py
+++ b/cooper/optim/constrained_optimizers/extrapolation_optimizer.py
@@ -158,9 +158,8 @@ class ExtrapolationConstrainedOptimizer(ConstrainedOptimizer):
         for primal_optimizer in self.primal_optimizers:
             primal_optimizer.extrapolation()  # type: ignore
 
-        # Call to dual_step flips sign of gradients, then triggers
-        # call to dual_optimizer.extrapolation and projects dual
-        # variables
+        # Call to dual_step triggers call to dual_optimizer.extrapolation and
+        # projects dual variables
         self.dual_step(call_extrapolation=True)
 
         # Zero gradients and recompute loss at t+1/2
@@ -169,9 +168,7 @@ class ExtrapolationConstrainedOptimizer(ConstrainedOptimizer):
         # For extrapolation, we need closure args here as the parameter
         # values will have changed in the update applied on the
         # extrapolation step
-        lagrangian = self.formulation.compute_lagrangian(
-            closure, *closure_args, **closure_kwargs
-        )  # type: ignore
+        lagrangian = self.formulation.compute_lagrangian(closure, *closure_args, **closure_kwargs)  # type: ignore
 
         # Populate gradients at extrapolation point
         self.formulation.backward(lagrangian)
@@ -184,13 +181,6 @@ class ExtrapolationConstrainedOptimizer(ConstrainedOptimizer):
         self.dual_step()
 
     def dual_step(self, call_extrapolation=False):
-
-        # Flip gradients for multipliers to perform ascent.
-        # We only do the flipping *right before* applying the optimizer step to
-        # avoid accidental double sign flips.
-        for multiplier in self.formulation.state():
-            if multiplier is not None:
-                multiplier.grad.mul_(-1.0)
 
         # Update multipliers based on current constraint violations (gradients)
         if call_extrapolation:

--- a/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
+++ b/cooper/optim/constrained_optimizers/simultaneous_optimizer.py
@@ -94,13 +94,6 @@ class SimultaneousConstrainedOptimizer(ConstrainedOptimizer):
 
     def dual_step(self):
 
-        # Flip gradients for multipliers to perform ascent.
-        # We only do the flipping *right before* applying the optimizer step to
-        # avoid accidental double sign flips.
-        for multiplier in self.formulation.state():
-            if multiplier is not None:
-                multiplier.grad.mul_(-1.0)
-
         # Update multipliers based on current constraint violations (gradients)
         self.dual_optimizer.step()
 

--- a/cooper/optim/extra_optimizers.py
+++ b/cooper/optim/extra_optimizers.py
@@ -151,6 +151,7 @@ class ExtraSGD(ExtragradientOptimizer):
         dampening: float = 0,
         weight_decay: float = 0,
         nesterov: bool = False,
+        maximize: bool = False,
     ):
         if lr is None or lr < 0.0:
             raise ValueError("Invalid learning rate: {}".format(lr))
@@ -165,6 +166,7 @@ class ExtraSGD(ExtragradientOptimizer):
             dampening=dampening,
             weight_decay=weight_decay,
             nesterov=nesterov,
+            maximize=maximize,
         )
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
@@ -180,10 +182,13 @@ class ExtraSGD(ExtragradientOptimizer):
         momentum = group["momentum"]
         dampening = group["dampening"]
         nesterov = group["nesterov"]
+        maximize = group["maximize"]
 
         if p.grad is None:
             return None
         d_p = p.grad.data
+        if maximize:
+            d_p = -d_p
         if weight_decay != 0:
             d_p.add_(weight_decay, p.data)
         if momentum != 0:
@@ -225,6 +230,7 @@ class ExtraAdam(ExtragradientOptimizer):
         eps: float = 1e-8,
         weight_decay: float = 0,
         amsgrad: bool = False,
+        maximize: bool = False,
     ):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
@@ -235,7 +241,12 @@ class ExtraAdam(ExtragradientOptimizer):
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
         defaults = dict(
-            lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, amsgrad=amsgrad
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            amsgrad=amsgrad,
+            maximize=maximize,
         )
         super(ExtraAdam, self).__init__(params, defaults)
 
@@ -248,6 +259,8 @@ class ExtraAdam(ExtragradientOptimizer):
         if p.grad is None:
             return None
         grad = p.grad.data
+        if group["maximize"]:
+            grad = -grad
         if grad.is_sparse:
             raise RuntimeError(
                 "Adam does not support sparse gradients, please consider SparseAdam instead"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ ignore_missing_imports = True
 [options]
 include_package_data = True
 install_requires =
-    torch>=1.8.1
+    torch>=1.12.0
     numpy>=1.21.0
 packages = find:
 python_requires = >=3.7
@@ -72,7 +72,7 @@ docs =
     matplotlib>=3.5.0,<4.0.0
     ipykernel>=6.5.0,<7.0.0
     ipywidgets>=7.6.0,<8.0.0
-    torchvision>=0.11.2,<1.0.0
+    torchvision>=0.13.0,<1.0.0
 tests =
     numpy==1.21.0
     pytest==6.2.5
@@ -82,7 +82,7 @@ examples =
     matplotlib>=3.5.0,<4.0.0
     ipykernel>=6.5.0,<7.0.0
     ipywidgets>=7.6.0,<8.0.0
-    torchvision>=0.11.2,<1.0.0
+    torchvision>=0.13.0,<1.0.0
 
 
 [options.packages.find]

--- a/tests/test_augmented_lagrangian.py
+++ b/tests/test_augmented_lagrangian.py
@@ -169,8 +169,7 @@ def test_manual_augmented_lagrangian(aim_device):
     assert torch.allclose(params, mktensor([0.058, -0.864]))
 
     # Check inequality multipliers
-    # Multiplier gradient signed is flipped inside step
-    assert torch.allclose(-formulation.state()[0].grad, mktensor([1.8060, -1.860636]))
+    assert torch.allclose(formulation.state()[0].grad, mktensor([1.8060, -1.860636]))
     assert torch.allclose(formulation.state()[0], mktensor([3.726, 0.0]))
 
     coop.dual_scheduler.step()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist =  py{37,38,39}-torch{18, 19, 110}-{linux,macos,windows}, lint, mypy
+envlist =  py{37,38,39}-torch{12, 13}-{linux,macos,windows}, lint, mypy
 isolated_build = true
 
 [gh-actions]
@@ -21,9 +21,8 @@ setenv =
 extras = tests
 whitelist_externals = pytest
 deps =
-    torch18: torch >= 1.8.0, < 1.9.0
-    torch19: torch >= 1.9.0, < 1.10.0
-    torch110: torch >= 1.10.0, < 1.11.0
+    torch12: torch >= 1.12.0, < 1.13.0
+    torch13: torch >= 1.13.0, < 1.14.0
 commands =
     pytest --basetemp={envtmpdir}
 


### PR DESCRIPTION
Closes #49 

## Changes

When instantiating a `dual_optimizer`, we set `maximize=True`.
Pytorch versions below 1.12 are no longer supported. `setup.cfg` and tox adjusted.

## Testing

Passing