### PR TITLE
Refactor `observed_constraints` into `dict[Constraint, ConstraintState]`

### DIFF
--- a/cooper/optim/constrained_optimizers/alternating_optimizer.py
+++ b/cooper/optim/constrained_optimizers/alternating_optimizer.py
@@ -142,7 +142,6 @@ class AlternatingPrimalDualOptimizer(BaseAlternatingOptimizer):
                         "Expected `compute_violations` to not populate the loss. "
                         "Please provide this value for the `compute_cmp_state` instead."
                     )
-                new_cmp_state.loss = cmp_state.loss
 
             except (NotImplementedError, TypeError):
                 # TODO(merajhashemi): This is a temporary fix to avoid breaking the tests

--- a/cooper/optim/constrained_optimizers/alternating_optimizer.py
+++ b/cooper/optim/constrained_optimizers/alternating_optimizer.py
@@ -143,9 +143,7 @@ class AlternatingPrimalDualOptimizer(BaseAlternatingOptimizer):
                         "Please provide this value for the `compute_cmp_state` instead."
                     )
 
-            except (NotImplementedError, TypeError):
-                # TODO(merajhashemi): This is a temporary fix to avoid breaking the tests
-                #  when `use_violation_fn=False`. Only NotImplementedError should be caught.
+            except NotImplementedError:
                 new_cmp_state = self.cmp.compute_cmp_state(**compute_cmp_state_kwargs)
 
         dual_lagrangian_store = new_cmp_state.compute_dual_lagrangian()

--- a/cooper/penalty_coefficient_updaters/penalty_coefficient_updaters.py
+++ b/cooper/penalty_coefficient_updaters/penalty_coefficient_updaters.py
@@ -13,7 +13,7 @@ class PenaltyCoefficientUpdater(abc.ABC):
         for constraint, constraint_state in observed_constraints.items():
             # If a constraint does not contribute to the dual update, we do not update
             # its penalty coefficient.
-            if constraint_state.contributes_to_dual_update:
+            if (constraint.penalty_coefficient is not None) and constraint_state.contributes_to_dual_update:
                 self.update_penalty_coefficient_(constraint, constraint_state)
 
     @abc.abstractmethod
@@ -51,6 +51,7 @@ class MultiplicativePenaltyCoefficientUpdater(PenaltyCoefficientUpdater):
         constraint_features, strict_constraint_features = constraint_state.extract_constraint_features()
         penalty_coefficient = constraint.penalty_coefficient
 
+        # TODO(merajhashemi): Make this block more readable
         values_for_observed = (
             penalty_coefficient.value
             if isinstance(penalty_coefficient, DensePenaltyCoefficient)

--- a/cooper/penalty_coefficient_updaters/penalty_coefficient_updaters.py
+++ b/cooper/penalty_coefficient_updaters/penalty_coefficient_updaters.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Sequence
 
 import torch
 
@@ -10,8 +9,8 @@ from cooper.multipliers import DensePenaltyCoefficient
 class PenaltyCoefficientUpdater(abc.ABC):
     """Abstract class for updating the penalty coefficient of a constraint."""
 
-    def step(self, observed_constraints: Sequence[tuple[Constraint, ConstraintState]]):
-        for constraint, constraint_state in observed_constraints:
+    def step(self, observed_constraints: dict[Constraint, ConstraintState]):
+        for constraint, constraint_state in observed_constraints.items():
             # If a constraint does not contribute to the dual update, we do not update
             # its penalty coefficient.
             if constraint_state.contributes_to_dual_update:

--- a/tests/helpers/cooper_test_utils.py
+++ b/tests/helpers/cooper_test_utils.py
@@ -107,7 +107,9 @@ class Toy2dCMP(cooper.ConstrainedMinimizationProblem):
         return loss_grad, torch.stack([cg0_grad, cg1_grad])
 
     def compute_violations(self, params) -> cooper.CMPState:
-        """Evaluates the constraint violations for this CMP."""
+        """Evaluates only the constraint violations for this CMP."""
+        if params is None:
+            raise NotImplementedError()
 
         param_x, param_y = params() if callable(params) else params
 
@@ -138,7 +140,7 @@ class Toy2dCMP(cooper.ConstrainedMinimizationProblem):
             cg0_state = cooper.ConstraintState(violation=cg0_violation)
             cg1_state = cooper.ConstraintState(violation=cg1_violation)
 
-        observed_constraints = [(getattr(self, "constraint_0"), cg0_state), (getattr(self, "constraint_1"), cg1_state)]
+        observed_constraints = {self.constraint_0: cg0_state, self.constraint_1: cg1_state}
 
         return cooper.CMPState(loss=None, observed_constraints=observed_constraints)
 

--- a/tests/test_alternating_surrogate.py
+++ b/tests/test_alternating_surrogate.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python
-
-"""Tests for Constrained Optimizer class."""
-
 import cooper_test_utils
 import pytest
 import testing_utils
 import torch
 
 import cooper
+
+USE_CONSTRAINT_SURROGATE = True
 
 
 @pytest.mark.parametrize("use_violation_fn", [True, False])
@@ -29,9 +27,14 @@ def test_manual_PrimalDual_surrogate(use_violation_fn, Toy2dCMP_problem_properti
     # Only performing this test for the case of a single primal optimizer
     assert isinstance(params, torch.nn.Parameter)
 
-    cmp = cooper_test_utils.Toy2dCMP(use_ineq_constraints=True, use_constraint_surrogate=True, device=device)
+    cmp = cooper_test_utils.Toy2dCMP(
+        use_ineq_constraints=True, use_constraint_surrogate=USE_CONSTRAINT_SURROGATE, device=device
+    )
 
     mktensor = testing_utils.mktensor(device=device)
+
+    PRIMAL_LR = 1e-2
+    DUAL_LR = 1e-2
 
     cooper_optimizer = cooper_test_utils.build_cooper_optimizer_for_Toy2dCMP(
         primal_optimizers=primal_optimizers,
@@ -39,69 +42,73 @@ def test_manual_PrimalDual_surrogate(use_violation_fn, Toy2dCMP_problem_properti
         extrapolation=False,
         alternation_type=cooper.optim.AlternationType.PRIMAL_DUAL,
         dual_optimizer_class=torch.optim.SGD,
-        dual_optimizer_kwargs={"lr": 1e-2},
+        dual_optimizer_kwargs={"lr": DUAL_LR},
     )
 
     roll_kwargs = {
         "compute_cmp_state_kwargs": dict(params=params),
-        "compute_violations_kwargs": dict(params=params) if use_violation_fn else {},
+        "compute_violations_kwargs": dict(params=params) if use_violation_fn else dict(params=None),
     }
 
     x0_y0 = mktensor([0.0, -1.0])
     lmbda0 = mktensor([0.0, 0.0])
 
     # ----------------------- First iteration -----------------------
-    # The returned LagrangianStore is computed after the primal update but before the
-    # dual update.
-    cmp_state, primal_ls_before_primal_update, dual_ls_after_primal_update = cooper_optimizer.roll(**roll_kwargs)
+    # The returned CMPState when using PrimalDual updates is measured _after_ performing
+    # the primal update.
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
     _cmp_state = cmp.compute_cmp_state(x0_y0)
 
     # No dual update yet, so the observed multipliers should be zero, matching lmdba0
-    observed_multipliers = torch.cat(primal_ls_before_primal_update.multiplier_values())
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
     assert torch.allclose(observed_multipliers, lmbda0)
 
     # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x0_y0 = cmp.analytical_gradients(x0_y0)
-    x1_y1 = x0_y0 - 1e-2 * (grads_x0_y0[0] + torch.sum(lmbda0 * grads_x0_y0[1]))
+    x1_y1 = x0_y0 - PRIMAL_LR * (grads_x0_y0[0] + torch.sum(lmbda0 * grads_x0_y0[1]))
     assert torch.allclose(params, x1_y1)
 
-    # Check primal and dual Lagrangians.
-    violations_before_primal_update = mktensor([_[1].violation for _ in _cmp_state.observed_constraints])
-    strict_violations_after_primal_update = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    # The value of the primal Lagrangian should be the loss at (x0, y0) plus the
+    # constraint contributions _before_ the primal update
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    assert torch.allclose(primal_ls.lagrangian, _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda0))
 
-    loss = _cmp_state.loss
-    primal_lagrangian0 = loss + torch.sum(violations_before_primal_update * lmbda0)
-    dual_lagrangian0 = torch.sum(strict_violations_after_primal_update * lmbda0)
-
-    assert torch.allclose(primal_ls_before_primal_update.lagrangian, primal_lagrangian0)
-    assert torch.allclose(dual_ls_after_primal_update.lagrangian, dual_lagrangian0)
+    strict_violations_after_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # after the primal update, using the original multipliers
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_after_primal_update * lmbda0))
 
     # Lambda update uses the violations after the primal update.
-    lmbda1 = torch.relu(lmbda0 + 1e-2 * strict_violations_after_primal_update)
+    # Note that the dual Lagrangian store does NOT include the updated multipliers
+    # since the update happens inside roll _after_ computing the Lagrangian store.
+    lmbda1 = torch.relu(lmbda0 + DUAL_LR * strict_violations_after_primal_update)
 
     # ----------------------- Second iteration -----------------------
-    cmp_state, primal_ls_before_primal_update, dual_ls_after_primal_update = cooper_optimizer.roll(**roll_kwargs)
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
     _cmp_state = cmp.compute_cmp_state(x1_y1)
 
-    observed_multipliers = torch.cat(primal_ls_before_primal_update.multiplier_values())
+    # At this stage we have carried out [primal_update, dual_update, primal_update], so
+    # we can verify that the observed multipliers have the right values after their
+    # update in the _previous_ step.
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
     assert torch.allclose(observed_multipliers, lmbda1)
 
+    # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x1_y1 = cmp.analytical_gradients(x1_y1)
-    x2_y2 = x1_y1 - 1e-2 * (grads_x1_y1[0] + torch.sum(lmbda1 * grads_x1_y1[1]))
+    x2_y2 = x1_y1 - PRIMAL_LR * (grads_x1_y1[0] + torch.sum(lmbda1 * grads_x1_y1[1]))
 
-    # NOTE: this test requires a relaxed tolerance of 1e-4
+    # NOTE: this test requires a relaxed tolerance of 1e-4. investigate why?
     assert torch.allclose(params, x2_y2, atol=1e-4)
 
-    # Check primal and dual Lagrangians.
-    violations_before_primal_update = mktensor([_[1].violation for _ in _cmp_state.observed_constraints])
-    strict_violations_after_primal_update = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    # The value of the primal Lagrangian should be the loss at (x1, y1) plus the
+    # constraint contributions _before_ the primal update
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    assert torch.allclose(primal_ls.lagrangian, _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda1))
 
-    loss = _cmp_state.loss
-    primal_lagrangian1 = loss + torch.sum(violations_before_primal_update * lmbda1)
-    dual_lagrangian1 = torch.sum(strict_violations_after_primal_update * lmbda1)
-
-    assert torch.allclose(primal_ls_before_primal_update.lagrangian, primal_lagrangian1)
-    assert torch.allclose(dual_ls_after_primal_update.lagrangian, dual_lagrangian1)
+    strict_violations_after_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # after the primal update
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_after_primal_update * lmbda1))
 
 
 def test_manual_DualPrimal_surrogate(Toy2dCMP_problem_properties, Toy2dCMP_params_init, device):
@@ -119,12 +126,17 @@ def test_manual_DualPrimal_surrogate(Toy2dCMP_problem_properties, Toy2dCMP_param
         use_multiple_primal_optimizers=False, params_init=Toy2dCMP_params_init
     )
 
-    # Only perfoming this test for the case of a single primal optimizer
+    # Only performing this test for the case of a single primal optimizer
     assert isinstance(params, torch.nn.Parameter)
 
-    cmp = cooper_test_utils.Toy2dCMP(use_ineq_constraints=True, use_constraint_surrogate=True, device=device)
+    cmp = cooper_test_utils.Toy2dCMP(
+        use_ineq_constraints=True, use_constraint_surrogate=USE_CONSTRAINT_SURROGATE, device=device
+    )
 
     mktensor = testing_utils.mktensor(device=device)
+
+    PRIMAL_LR = 1e-2
+    DUAL_LR = 1e-2
 
     cooper_optimizer = cooper_test_utils.build_cooper_optimizer_for_Toy2dCMP(
         primal_optimizers=primal_optimizers,
@@ -132,88 +144,72 @@ def test_manual_DualPrimal_surrogate(Toy2dCMP_problem_properties, Toy2dCMP_param
         extrapolation=False,
         alternation_type=cooper.optim.AlternationType.DUAL_PRIMAL,
         dual_optimizer_class=torch.optim.SGD,
-        dual_optimizer_kwargs={"lr": 1e-2},
+        dual_optimizer_kwargs={"lr": DUAL_LR},
     )
+
+    roll_kwargs = {"compute_cmp_state_kwargs": dict(params=params)}
 
     x0_y0 = mktensor([0.0, -1.0])
     lmbda0 = mktensor([0.0, 0.0])
 
     # ----------------------- First iteration -----------------------
+    # The CMPState returned when using DualPrimal is measured _before any_ updates
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
+    _cmp_state = cmp.compute_cmp_state(x0_y0)
 
-    cmp_state, primal_lagrangian_store_after_roll, dual_lagrangian_store_after_roll = cooper_optimizer.roll(
-        compute_cmp_state_kwargs=dict(params=params)
-    )
-    violations = mktensor([_[1].violation for _ in cmp_state.observed_constraints])
-    strict_violations = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    strict_violations_before_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    lmbda1 = torch.relu(lmbda0 + DUAL_LR * strict_violations_before_primal_update)
 
-    # DualPrimal optimizer only computes the CMPSTate and violations once, using the
-    # existing primal parameters. Therefore, the CMPState using the iterates _before_
-    # the roll should match the CMPState returned by the roll.
-    manual_cmp_state = cmp.compute_cmp_state(x0_y0)
-    manual_violations = mktensor([_[1].violation for _ in manual_cmp_state.observed_constraints])
-    manual_strict_violations = mktensor([_[1].strict_violation for _ in manual_cmp_state.observed_constraints])
-    assert torch.isclose(cmp_state.loss, manual_cmp_state.loss)
-    assert torch.allclose(violations, manual_violations)
-    assert torch.allclose(strict_violations, manual_strict_violations)
-
-    # Computing the dual update manually to ensure correctness
-    # The multipliers are updated based on the strict violations
-    lmbda1 = torch.relu(lmbda0 + 1e-2 * strict_violations)
-    # After the dual update, the multipliers will be used to weight the (potentially
-    # differentiable) violations in the primal Lagrangian
-    observed_multipliers = torch.cat(primal_lagrangian_store_after_roll.multiplier_values())
+    # The primal Lagrangian store uses the multipliers _after_ the dual update
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
     assert torch.allclose(observed_multipliers, lmbda1)
-    primal_lagrangian0 = cmp_state.loss + torch.sum(violations * lmbda1)
-    assert torch.allclose(primal_lagrangian_store_after_roll.lagrangian, primal_lagrangian0)
 
-    # The dual Lagrangian returned by the LagrangianStore is computed using the dual
-    # variables _before_ the dual update, so it should match the Lagrangian computed
-    # using lmbda0 (the dual parameters before roll)
-    dual_lagrangian0 = torch.sum(strict_violations * lmbda0)
-    if not torch.allclose(dual_lagrangian_store_after_roll.lagrangian, dual_lagrangian0):
-        breakpoint()
-
-    # Computing the primal update
     # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x0_y0 = cmp.analytical_gradients(x0_y0)
-    x1_y1 = x0_y0 - 1e-2 * (grads_x0_y0[0] + torch.sum(lmbda1 * grads_x0_y0[1]))
-    # NOTE: this test requires a relaxed tolerance of 1e-4
+    # Need to use the updated multipliers when computing the primal update
+    x1_y1 = x0_y0 - PRIMAL_LR * (grads_x0_y0[0] + torch.sum(lmbda1 * grads_x0_y0[1]))
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
     assert torch.allclose(params, x1_y1, atol=1e-4)
 
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # before the primal update, using the original multipliers
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_before_primal_update * lmbda0))
+
+    # The value of the primal Lagrangian should be the loss at (x0, y0) plus the
+    # constraint contributions _before_ the primal update; but using the updated
+    # multipliers
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    assert torch.allclose(primal_ls.lagrangian, _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda1))
+
     # ----------------------- Second iteration -----------------------
-    cmp_state, primal_lagrangian_store_after_roll, dual_lagrangian_store_after_roll = cooper_optimizer.roll(
-        compute_cmp_state_kwargs=dict(params=params)
-    )
-    violations = mktensor([_[1].violation for _ in cmp_state.observed_constraints])
-    strict_violations = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
+    _cmp_state = cmp.compute_cmp_state(x1_y1)
 
-    manual_cmp_state = cmp.compute_cmp_state(x1_y1)
-    manual_violations = mktensor([_[1].violation for _ in manual_cmp_state.observed_constraints])
-    manual_strict_violations = mktensor([_[1].strict_violation for _ in manual_cmp_state.observed_constraints])
-    # NOTE: the following tests requires a relaxed tolerance of 1e-4
-    assert torch.isclose(cmp_state.loss, manual_cmp_state.loss, atol=1e-4)
-    assert torch.allclose(violations, manual_violations, atol=1e-4)
-    assert torch.allclose(strict_violations, manual_strict_violations, atol=1e-4)
+    strict_violations_before_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    lmbda2 = torch.relu(lmbda1 + DUAL_LR * strict_violations_before_primal_update)
 
-    lmbda2 = torch.relu(lmbda1 + 1e-2 * strict_violations)
-
-    observed_multipliers = torch.cat(primal_lagrangian_store_after_roll.multiplier_values())
+    # The primal Lagrangian store uses the multipliers _after_ the dual update
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
     assert torch.allclose(observed_multipliers, lmbda2)
 
-    primal_lagrangian1 = cmp_state.loss + torch.sum(violations * lmbda2)
-    assert torch.allclose(primal_lagrangian_store_after_roll.lagrangian, primal_lagrangian1)
-
-    dual_lagrangian1 = torch.sum(strict_violations * lmbda1)
-    assert torch.allclose(dual_lagrangian_store_after_roll.lagrangian, dual_lagrangian1)
-
+    # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x1_y1 = cmp.analytical_gradients(x1_y1)
-    x2_y2 = x1_y1 - 1e-2 * (grads_x1_y1[0] + torch.sum(lmbda2 * grads_x1_y1[1]))
-
-    # NOTE: this test requires a relaxed tolerance of 1e-4
+    # Need to use the updated multipliers when computing the primal update
+    x2_y2 = x1_y1 - PRIMAL_LR * (grads_x1_y1[0] + torch.sum(lmbda2 * grads_x1_y1[1]))
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
     assert torch.allclose(params, x2_y2, atol=1e-4)
 
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # before the second primal update, using multipliers before their second update
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_before_primal_update * lmbda1))
 
-# TODO(juan43ramirez): implement
+    # The value of the primal Lagrangian should be the loss at (x1, y1) plus the
+    # constraint contributions _before_ the primal update; but using the updated
+    # multipliers
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    target_primal_lagrangian = _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda2)
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
+    assert torch.allclose(primal_ls.lagrangian, target_primal_lagrangian, atol=1e-4)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_extrapolation.py
+++ b/tests/test_extrapolation.py
@@ -41,13 +41,13 @@ def test_manual_extrapolation(Toy2dCMP_problem_properties, Toy2dCMP_params_init,
     primal_lagrangian_store = cmp_state.compute_primal_lagrangian()
     dual_lagrangian_store = cmp_state.compute_dual_lagrangian()
     lagrangian = primal_lagrangian_store.lagrangian
-    observed_multiplier_values = primal_lagrangian_store.multiplier_values()
+    observed_multiplier_values = primal_lagrangian_store.observed_multiplier_values()
 
     # Check loss, proxy and non-proxy defects after forward pass
     assert torch.allclose(lagrangian, mktensor(2.0))
     assert torch.allclose(cmp_state.loss, mktensor(2.0))
 
-    for (_, constraint_state), target_value in zip(cmp_state.observed_constraints, [2.0, -2.0]):
+    for (_, constraint_state), target_value in zip(cmp_state.observed_constraints.items(), [2.0, -2.0]):
         assert torch.allclose(constraint_state.violation, mktensor([target_value]))
     # Multiplier initialization
     for multiplier, target_value in zip(observed_multiplier_values, [0.0, 0.0]):
@@ -58,7 +58,7 @@ def test_manual_extrapolation(Toy2dCMP_problem_properties, Toy2dCMP_params_init,
     assert torch.allclose(params.grad, mktensor([0.0, -4.0]))
 
     # Dual gradients must match the constraint violations.
-    for constraint, constraint_state in cmp_state.observed_constraints:
+    for constraint, constraint_state in cmp_state.observed_constraints.items():
         assert torch.allclose(constraint.multiplier.weight.grad, constraint_state.violation)
 
     cooper_optimizer.step(call_extrapolation=True)

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-
-"""Tests for Constrained Optimizer class."""
-
 import cooper_test_utils
 import pytest
 import testing_utils
@@ -9,26 +5,35 @@ import torch
 
 import cooper
 
+USE_CONSTRAINT_SURROGATE = True
 
-def test_manual_proxy(Toy2dCMP_problem_properties, Toy2dCMP_params_init, device):
-    """Test first step of simultaneous GDA updates with surrogates on toy 2D problem."""
 
-    if not Toy2dCMP_problem_properties["use_ineq_constraints"]:
-        pytest.skip("Surrogate update tests require a problem with constraints.")
+def test_manual_simultaneous_surrogate(Toy2dCMP_problem_properties, Toy2dCMP_params_init, device):
+    """Test first two iterations of DualPrimal alternating GDA updates on a toy 2D
+    problem with surrogate constraints."""
+
+    use_ineq_constraints = Toy2dCMP_problem_properties["use_ineq_constraints"]
+    if not use_ineq_constraints:
+        pytest.skip("Alternating updates requires a problem with constraints.")
 
     if not torch.allclose(Toy2dCMP_params_init, torch.tensor([0.0, -1.0], device=device)):
-        pytest.skip("Manual surrogate test only considers the case of initialization at [0, -1]")
+        pytest.skip("Manual alternating test only considers the case of initialization at [0, -1]")
 
     params, primal_optimizers = cooper_test_utils.build_params_and_primal_optimizers(
         use_multiple_primal_optimizers=False, params_init=Toy2dCMP_params_init
     )
 
-    # Only perfoming this test for the case of a single primal optimizer
+    # Only performing this test for the case of a single primal optimizer
     assert isinstance(params, torch.nn.Parameter)
 
-    cmp = cooper_test_utils.Toy2dCMP(use_ineq_constraints=True, use_constraint_surrogate=True, device=device)
+    cmp = cooper_test_utils.Toy2dCMP(
+        use_ineq_constraints=True, use_constraint_surrogate=USE_CONSTRAINT_SURROGATE, device=device
+    )
 
     mktensor = testing_utils.mktensor(device=device)
+
+    PRIMAL_LR = 1e-2
+    DUAL_LR = 1e-2
 
     cooper_optimizer = cooper_test_utils.build_cooper_optimizer_for_Toy2dCMP(
         primal_optimizers=primal_optimizers,
@@ -36,7 +41,7 @@ def test_manual_proxy(Toy2dCMP_problem_properties, Toy2dCMP_params_init, device)
         extrapolation=False,
         alternation_type=cooper.optim.AlternationType.FALSE,
         dual_optimizer_class=torch.optim.SGD,
-        dual_optimizer_kwargs={"lr": 1e-2},
+        dual_optimizer_kwargs={"lr": DUAL_LR},
     )
 
     roll_kwargs = {"compute_cmp_state_kwargs": dict(params=params)}
@@ -44,50 +49,65 @@ def test_manual_proxy(Toy2dCMP_problem_properties, Toy2dCMP_params_init, device)
     x0_y0 = mktensor([0.0, -1.0])
     lmbda0 = mktensor([0.0, 0.0])
 
-    # ------------ First step of surrogate updates ------------
-    cmp_state, primal_lagrangian_store, dual_lagrangian_store = cooper_optimizer.roll(**roll_kwargs)
-    violations = mktensor([_[1].violation for _ in cmp_state.observed_constraints])
-    strict_violations = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    # ----------------------- First iteration -----------------------
+    # The CMPState returned when using simultaneous updates is measured _before any_ updates
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
+    _cmp_state = cmp.compute_cmp_state(x0_y0)
 
-    # Check primal and dual Lagrangians
-    primal_lagrangian0 = cmp_state.loss + torch.sum(violations * lmbda0)
-    dual_lagrangian0 = torch.sum(strict_violations * lmbda0)
+    strict_violations_before_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    lmbda1 = torch.relu(lmbda0 + DUAL_LR * strict_violations_before_primal_update)
 
-    assert torch.allclose(primal_lagrangian_store.lagrangian, primal_lagrangian0)
-    assert torch.allclose(dual_lagrangian_store.lagrangian, dual_lagrangian0)
+    # The primal Lagrangian store uses the original multipliers
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
+    assert torch.allclose(observed_multipliers, lmbda0)
 
     # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x0_y0 = cmp.analytical_gradients(x0_y0)
-    x1_y1 = x0_y0 - 1e-2 * (grads_x0_y0[0] + torch.sum(lmbda0 * grads_x0_y0[1]))
-    assert torch.allclose(params, x1_y1)
+    # Need to use the original multipliers when computing the primal update
+    x1_y1 = x0_y0 - PRIMAL_LR * (grads_x0_y0[0] + torch.sum(lmbda0 * grads_x0_y0[1]))
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
+    assert torch.allclose(params, x1_y1, atol=1e-4)
 
-    # Observed multipliers should be zero, matching lmdba0
-    assert torch.allclose(torch.cat(primal_lagrangian_store.multiplier_values()), lmbda0)
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # before the primal update, using the original multipliers
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_before_primal_update * lmbda0))
 
-    lmbda1 = torch.relu(lmbda0 + 1e-2 * strict_violations)
+    # The value of the primal Lagrangian should be the loss at (x0, y0) plus the
+    # constraint contributions; using both original multiplier and primal params
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    assert torch.allclose(primal_ls.lagrangian, _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda0))
 
-    # ------------ Second step of surrogate updates ------------
-    cmp_state, primal_lagrangian_store, dual_lagrangian_store = cooper_optimizer.roll(**roll_kwargs)
-    violations = mktensor([_[1].violation for _ in cmp_state.observed_constraints])
-    strict_violations = mktensor([_[1].strict_violation for _ in cmp_state.observed_constraints])
+    # ----------------------- Second iteration -----------------------
+    cmp_state, primal_ls, dual_ls = cooper_optimizer.roll(**roll_kwargs)
+    _cmp_state = cmp.compute_cmp_state(x1_y1)
 
-    # Check primal and dual Lagrangians
-    primal_lagrangian1 = cmp_state.loss + torch.sum(violations * lmbda1)
-    dual_lagrangian1 = torch.sum(strict_violations * lmbda1)
+    strict_violations_before_primal_update = mktensor(list(cmp_state.observed_strict_violations()))
+    lmbda2 = torch.relu(lmbda1 + DUAL_LR * strict_violations_before_primal_update)  # noqa: F841
 
-    assert torch.allclose(primal_lagrangian_store.lagrangian, primal_lagrangian1)
-    assert torch.allclose(dual_lagrangian_store.lagrangian, dual_lagrangian1)
+    # The primal Lagrangian store uses the multipliers before updating them
+    observed_multipliers = torch.cat(list(primal_ls.observed_multiplier_values()))
+    assert torch.allclose(observed_multipliers, lmbda1)
 
     # analytical_gradients computes the gradients of the loss and surrogate constraints
     grads_x1_y1 = cmp.analytical_gradients(x1_y1)
-    x2_y2 = x1_y1 - 1e-2 * (grads_x1_y1[0] + torch.sum(lmbda1 * grads_x1_y1[1]))
-
-    # NOTE: this test requires a relaxed tolerance of 1e-4
+    # Need to use the received multipliers when computing the primal update
+    x2_y2 = x1_y1 - PRIMAL_LR * (grads_x1_y1[0] + torch.sum(lmbda1 * grads_x1_y1[1]))
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
     assert torch.allclose(params, x2_y2, atol=1e-4)
 
-    assert torch.allclose(torch.cat(primal_lagrangian_store.multiplier_values()), lmbda1)
+    # The value of the dual Lagrangian should only count the constraint contributions
+    # before the second primal update, using multipliers before their second update
+    assert torch.allclose(dual_ls.lagrangian, torch.sum(strict_violations_before_primal_update * lmbda1))
+
+    # The value of the primal Lagrangian should be the loss at (x1, y1) plus the
+    # constraint contributions _before_ the second primal or dual updates
+    violations_before_primal_update = mktensor(list(_cmp_state.observed_violations()))
+    target_primal_lagrangian = _cmp_state.loss + torch.sum(violations_before_primal_update * lmbda1)
+    # TODO(galllego-posada): check if need for relaxed tolerance comes from using surrogate constraints?
+    assert torch.allclose(primal_ls.lagrangian, target_primal_lagrangian, atol=1e-4)
 
 
+# TODO(gallego-posada): identify what the blocker is for implementing this test and report back
 # TODO(juan43ramirez): implement
 # def test_convergence_surrogate(
 #     Toy2dCMP_problem_properties, Toy2dCMP_params_init, use_multiple_primal_optimizers, device

--- a/tutorials/scripts/plot_gaussian_mixture.py
+++ b/tutorials/scripts/plot_gaussian_mixture.py
@@ -108,7 +108,7 @@ class MixtureSeparation(cooper.ConstrainedMinimizationProblem):
         super().__init__()
 
         constraint_type = cooper.ConstraintType.INEQUALITY
-        self.constraint = cooper.Constraint(
+        self.rate_constraint = cooper.Constraint(
             constraint_type=constraint_type,
             formulation_type=cooper.LagrangianFormulation,
             multiplier=cooper.multipliers.DenseMultiplier(constraint_type=constraint_type, num_constraints=1),
@@ -138,7 +138,7 @@ class MixtureSeparation(cooper.ConstrainedMinimizationProblem):
             strict_violation = self.constraint_level - prop_0
 
         constraint_state = cooper.ConstraintState(violation=differentiable_violation, strict_violation=strict_violation)
-        return cooper.CMPState(loss=loss, observed_constraints=[(self.constraint, constraint_state)])
+        return cooper.CMPState(loss=loss, observed_constraints={self.rate_constraint: constraint_state})
 
 
 def train(problem_name, inputs, targets, num_iters=5000, lr=1e-2, constraint_level=0.7):

--- a/tutorials/scripts/plot_infrequent_true_constraint.py
+++ b/tutorials/scripts/plot_infrequent_true_constraint.py
@@ -96,7 +96,7 @@ class MinNormWithSingularValueConstraints(cooper.ConstrainedMinimizationProblem)
         multiplier = cooper.multipliers.DenseMultiplier(
             num_constraints=1, constraint_type=constraint_type, device=DEVICE
         )
-        self.constraint = cooper.Constraint(
+        self.sv_constraint = cooper.Constraint(
             constraint_type=constraint_type,
             formulation_type=cooper.LagrangianFormulation,
             multiplier=multiplier,
@@ -132,7 +132,7 @@ class MinNormWithSingularValueConstraints(cooper.ConstrainedMinimizationProblem)
             contributes_to_dual_update=False,
         )
 
-        return cooper.CMPState(loss=objective, observed_constraints=[(self.constraint, constraint_state)])
+        return cooper.CMPState(loss=objective, observed_constraints={self.sv_constraint: constraint_state})
 
     @torch.no_grad()
     def compute_geometric_mean(self, X: torch.Tensor) -> torch.Tensor:
@@ -158,7 +158,7 @@ class MinNormWithSingularValueConstraints(cooper.ConstrainedMinimizationProblem)
             contributes_to_dual_update=True,
         )
 
-        return cooper.CMPState(loss=objective, observed_constraints=[(self.constraint, constraint_state)])
+        return cooper.CMPState(loss=objective, observed_constraints={self.sv_constraint, constraint_state})
 
 
 def run_experiment(dim_y, dim_z, constraint_level, max_iter, tolerance, freq_for_dual_update, primal_lr, dual_lr):

--- a/tutorials/scripts/plot_min_norm.py
+++ b/tutorials/scripts/plot_min_norm.py
@@ -130,7 +130,7 @@ class MinNormWithLinearConstraints(cooper.ConstrainedMinimizationProblem):
         loss = torch.linalg.vector_norm(x) ** 2
         violation = (sampled_equations @ x - sampled_RHS).view(-1)
         constraint_state = cooper.ConstraintState(violation=violation, constraint_features=indices)
-        return cooper.CMPState(loss=loss, observed_constraints=[(self.eq_constraint, constraint_state)])
+        return cooper.CMPState(loss=loss, observed_constraints={self.eq_constraint: constraint_state})
 
 
 def run_experiment(
@@ -209,7 +209,7 @@ def plot_results(state_histories) -> None:
         ax[exp_id, 3].set_yscale("log")
         ax[exp_id, 3].axhline(0, color="red", linestyle="--", alpha=0.3)
 
-    ax[0, 0].set_title(r"$\|x\|^2_2 $ vs $\|x^*\|^2_2$")
+    ax[0, 0].set_title(r"$\|x\|^2_2 $ / $\|x^*\|^2_2$")
     ax[0, 1].set_title("Multipliers")
     ax[0, 2].set_title(r"$\|x - x^*\|_\infty$")
     ax[0, 3].set_title(r"$\|Ax - b\|_\infty$")


### PR DESCRIPTION
## Changes

* Changed `observed_constraints` attribute of `CMPState` to be a dictionary with `Constraint` keys and `ConstraintState` values
* Similarly, refactored `constraint_measurements` to be a dictionary with `Constraint` keys and `ConstraintMeasurement` values
* Added utility function for retrieving `observed_multiplier_values` from `LagrangianStore` 
* Added utility function for retrieving `observed_violations` and `observed_violations` from `CMPState`
* Updated all tutorials to use new dict format of `observed_constraints`
* Add logic so penalty coefficient updaters skip constraints that do not have penalty coefficients associated. 
  * @merajhashemi At the moment the skipping happens silently, do we want to raise a warning/error?
  * This behavior is a result of passing the entire `observed_constraints` to the updater (which includes some with and some without AugmentedLagrangianFormulations, and thus penalty coefficients)
  * I believe it is convenient to be able to pass the entire dict of observed constraints without filtering, so I am in favor of keeping the skipping silent as it is now.
  * Maybe we want to add a "strict" flag (default to `False`) to the updater `step` and raise error when `strict` and attempt to "update penalty coefficient" for constraint without penalty coefficient.
* Remove loss patching in PrimalDual updates

⚠️ A consequence (feature? 🙃) of the new dict-like for approach `observed_constraints` is that it is not possible to "repeat a constraint" in `observed_constraints` since the `Constraint` objects are used as keys.

## Testing

* All tests passing on CPU
* All tutorials run
* Added TODOs on the Augmented Lagrangian tutorial since it is not giving the correct results
