### PR TITLE
Fix: make pylance happy by re-exporting submodules

### DIFF
--- a/src/cooper/__init__.py
+++ b/src/cooper/__init__.py
@@ -20,3 +20,18 @@ except PackageNotFoundError:
     warnings.warn("Could not retrieve Cooper version!")
     del warnings
 del version, PackageNotFoundError
+
+
+__all__ = [
+    "CMPState",
+    "ConstrainedMinimizationProblem",
+    "Constraint",
+    "ConstraintState",
+    "ConstraintType",
+    "LagrangianStore",
+    "__version__",
+    "formulations",
+    "multipliers",
+    "optim",
+    "penalty_coefficients",
+]

--- a/src/cooper/cmp.py
+++ b/src/cooper/cmp.py
@@ -14,6 +14,12 @@ from cooper.constraints import Constraint, ConstraintState
 from cooper.multipliers import Multiplier
 from cooper.penalty_coefficients import PenaltyCoefficient
 
+__all__ = [
+    "CMPState",
+    "ConstrainedMinimizationProblem",
+    "LagrangianStore",
+]
+
 
 @dataclass
 class LagrangianStore:

--- a/src/cooper/constraints/__init__.py
+++ b/src/cooper/constraints/__init__.py
@@ -3,3 +3,8 @@
 
 from .constraint import Constraint
 from .constraint_state import ConstraintState
+
+__all__ = [
+    "Constraint",
+    "ConstraintState",
+]

--- a/src/cooper/formulations/__init__.py
+++ b/src/cooper/formulations/__init__.py
@@ -8,3 +8,11 @@ from .formulations import (
     Lagrangian,
     QuadraticPenalty,
 )
+
+__all__ = [
+    "AugmentedLagrangian",
+    "ContributionStore",
+    "Formulation",
+    "Lagrangian",
+    "QuadraticPenalty",
+]

--- a/src/cooper/multipliers/__init__.py
+++ b/src/cooper/multipliers/__init__.py
@@ -2,3 +2,11 @@
 # Licensed under the MIT License.
 
 from .multipliers import DenseMultiplier, ExplicitMultiplier, ImplicitMultiplier, IndexedMultiplier, Multiplier
+
+__all__ = [
+    "DenseMultiplier",
+    "ExplicitMultiplier",
+    "ImplicitMultiplier",
+    "IndexedMultiplier",
+    "Multiplier",
+]

--- a/src/cooper/optim/__init__.py
+++ b/src/cooper/optim/__init__.py
@@ -1,7 +1,30 @@
 # Copyright (C) 2025 The Cooper Developers.
 # Licensed under the MIT License.
 
-from .constrained_optimizers import *  # noqa: F403
+from .constrained_optimizers import (
+    AlternatingDualPrimalOptimizer,
+    AlternatingPrimalDualOptimizer,
+    ConstrainedOptimizer,
+    ExtrapolationConstrainedOptimizer,
+    SimultaneousOptimizer,
+)
 from .optimizer import CooperOptimizer, CooperOptimizerState, RollOut
-from .torch_optimizers import *  # noqa: F403
+from .torch_optimizers import ExtraAdam, ExtragradientOptimizer, ExtraSGD, nuPI, nuPIInitType
 from .unconstrained_optimizer import UnconstrainedOptimizer
+
+__all__ = [
+    "AlternatingDualPrimalOptimizer",
+    "AlternatingPrimalDualOptimizer",
+    "ConstrainedOptimizer",
+    "CooperOptimizer",
+    "CooperOptimizerState",
+    "ExtraAdam",
+    "ExtraSGD",
+    "ExtragradientOptimizer",
+    "ExtrapolationConstrainedOptimizer",
+    "RollOut",
+    "SimultaneousOptimizer",
+    "UnconstrainedOptimizer",
+    "nuPI",
+    "nuPIInitType",
+]

--- a/src/cooper/optim/torch_optimizers/__init__.py
+++ b/src/cooper/optim/torch_optimizers/__init__.py
@@ -3,3 +3,11 @@
 
 from .extragradient import ExtraAdam, ExtragradientOptimizer, ExtraSGD
 from .nupi_optimizer import nuPI, nuPIInitType
+
+__all__ = [
+    "ExtraAdam",
+    "ExtraSGD",
+    "ExtragradientOptimizer",
+    "nuPI",
+    "nuPIInitType",
+]

--- a/src/cooper/penalty_coefficients/__init__.py
+++ b/src/cooper/penalty_coefficients/__init__.py
@@ -7,3 +7,12 @@ from .penalty_coefficient_updaters import (
     PenaltyCoefficientUpdater,
 )
 from .penalty_coefficients import DensePenaltyCoefficient, IndexedPenaltyCoefficient, PenaltyCoefficient
+
+__all__ = [
+    "AdditivePenaltyCoefficientUpdater",
+    "DensePenaltyCoefficient",
+    "IndexedPenaltyCoefficient",
+    "MultiplicativePenaltyCoefficientUpdater",
+    "PenaltyCoefficient",
+    "PenaltyCoefficientUpdater",
+]

--- a/src/cooper/utils/__init__.py
+++ b/src/cooper/utils/__init__.py
@@ -3,3 +3,9 @@
 
 from .annotations import ConstraintType, OneOrSequence
 from .utils import ensure_sequence
+
+__all__ = [
+    "ConstraintType",
+    "OneOrSequence",
+    "ensure_sequence",
+]


### PR DESCRIPTION
Closes #101

## Changes

Re-export submodules in `__init__.py` files.
Disabled [useless-import-alias check](https://docs.astral.sh/ruff/rules/useless-import-alias/#useless-import-alias-plc0414) from ruff.

## Testing
All tests in `pre-commit` and `pytest` passed.

## References
https://github.com/microsoft/pylance-release/issues/2953#issuecomment-1168408943